### PR TITLE
feat(pr-21): add PlanarFlow and SylvesterFlow bijections

### DIFF
--- a/src/gauss_flows/__init__.py
+++ b/src/gauss_flows/__init__.py
@@ -31,9 +31,11 @@ from gauss_flows._src.transforms import (
     MixtureGaussianCDF,
     MixtureLogisticCDF,
     OrthogonalRotation,
+    PlanarFlow,
     RQSplineCoupling,
     RQSplineMarginal,
     Squeeze,
+    SylvesterFlow,
 )
 
 
@@ -52,9 +54,11 @@ __all__ = [
     "MixtureGaussianCDF",
     "MixtureLogisticCDF",
     "OrthogonalRotation",
+    "PlanarFlow",
     "RQSplineCoupling",
     "RQSplineMarginal",
     "Squeeze",
+    "SylvesterFlow",
     "coupling_gaussianization_flow",
     "entropy",
     "fit_gaussianization_flow",

--- a/src/gauss_flows/_src/transforms/__init__.py
+++ b/src/gauss_flows/_src/transforms/__init__.py
@@ -3,6 +3,10 @@
 Re-exports all transform classes from the sub-modules.
 """
 
+from gauss_flows._src.transforms.classic import (
+    PlanarFlow,
+    SylvesterFlow,
+)
 from gauss_flows._src.transforms.conv import (
     ActNorm,
     HaarWavelet,
@@ -41,7 +45,9 @@ __all__ = [
     "MixtureGaussianCDF",
     "MixtureLogisticCDF",
     "OrthogonalRotation",
+    "PlanarFlow",
     "RQSplineCoupling",
     "RQSplineMarginal",
     "Squeeze",
+    "SylvesterFlow",
 ]

--- a/src/gauss_flows/_src/transforms/classic.py
+++ b/src/gauss_flows/_src/transforms/classic.py
@@ -1,0 +1,204 @@
+"""Classic low-expressivity normalizing flow bijections.
+
+Both transforms predate coupling and spline flows. They are useful as
+teaching baselines and as variational-inference-only flows: they have no
+algebraic inverse, so they can be used to sample from ``base -> data`` but
+cannot evaluate ``log_prob`` on arbitrary points. Use
+:meth:`flowjax.distributions.Transformed.sample_and_log_prob` in the VI
+setting.
+
+References:
+    Rezende & Mohamed 2015, *Variational Inference with Normalizing Flows*.
+    van den Berg et al. 2018, *Sylvester Normalizing Flows for VI*.
+"""
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+import jax.random as jr
+from flowjax.bijections import AbstractBijection
+from jax import Array
+from jax.nn import softplus
+from jaxtyping import ArrayLike, PRNGKeyArray
+
+
+_NO_INVERSE_MSG = (
+    "{name} has no algebraic inverse; use sample_and_log_prob in the "
+    "generative direction (VI). log_prob of arbitrary points is not supported."
+)
+
+
+class PlanarFlow(AbstractBijection):
+    """Planar flow bijection (Rezende & Mohamed 2015).
+
+    Applies ``y = x + u_hat * tanh(w . x + b)`` where ``u_hat`` is the
+    projection of ``u`` that guarantees ``w . u_hat >= -1`` (the
+    invertibility condition from the original paper).
+
+    Args:
+        key: JAX random key.
+        shape: Shape of the input ``(n_dims,)``.
+        scale_init: Std of the Gaussian used to initialise ``u`` and ``w``.
+
+    Note:
+        No algebraic inverse; ``inverse_and_log_det`` raises
+        :class:`NotImplementedError`. Use only in the generative
+        (sample / VI) direction.
+    """
+
+    shape: tuple[int, ...]
+    cond_shape: ClassVar[None] = None
+    u: Array
+    w: Array
+    b: Array
+
+    def __init__(
+        self,
+        key: PRNGKeyArray,
+        shape: tuple[int, ...],
+        scale_init: float = 0.01,
+    ):
+        if len(shape) != 1:
+            raise ValueError("PlanarFlow only supports 1D inputs.")
+        d = shape[0]
+        k_u, k_w = jr.split(key)
+        self.shape = shape
+        self.u = jr.normal(k_u, (d,)) * scale_init
+        self.w = jr.normal(k_w, (d,)) * scale_init
+        self.b = jnp.zeros(())
+
+    def _u_hat(self) -> Array:
+        wu = jnp.dot(self.w, self.u)
+        m = -1.0 + softplus(wu)
+        w_norm_sq = jnp.sum(self.w**2) + 1e-12
+        return self.u + (m - wu) * self.w / w_norm_sq
+
+    def transform_and_log_det(self, x: ArrayLike, condition=None):
+        x = jnp.asarray(x)
+        u_hat = self._u_hat()
+        a = jnp.dot(self.w, x) + self.b
+        y = x + u_hat * jnp.tanh(a)
+        psi_dot_w = (1.0 - jnp.tanh(a) ** 2) * jnp.dot(u_hat, self.w)
+        log_det = jnp.log(jnp.abs(1.0 + psi_dot_w) + 1e-12)
+        return y, log_det
+
+    def inverse_and_log_det(self, y: ArrayLike, condition=None):
+        raise NotImplementedError(_NO_INVERSE_MSG.format(name="PlanarFlow"))
+
+
+class SylvesterFlow(AbstractBijection):
+    """Sylvester normalizing flow (van den Berg et al. 2018).
+
+    Generalises :class:`PlanarFlow` to rank ``M <= D``:
+
+    .. code-block::
+
+        y = x + Q @ R_tilde @ tanh(R @ Q^T @ x + b)
+
+    where ``Q in R^{D x M}`` has orthonormal columns (parameterised via
+    ``M`` Householder reflections on ``I_D``), and ``R``, ``R_tilde`` are
+    ``M x M`` upper-triangular matrices with diagonal entries constrained
+    via ``tanh`` (to keep ``|diag(R) * diag(R_tilde)| < 1``, which is
+    sufficient for invertibility).
+
+    Via Sylvester's determinant identity the log-abs-det reduces to a
+    sum over the ``M`` diagonal entries.
+
+    Args:
+        key: JAX random key.
+        shape: Shape of the input ``(n_dims,)``.
+        rank: Rank ``M`` of the flow. Defaults to the full input dim.
+        scale_init: Std of Gaussian init for the triangular strict upper
+            entries.
+
+    Note:
+        No algebraic inverse; ``inverse_and_log_det`` raises
+        :class:`NotImplementedError`. Use only in the generative direction.
+    """
+
+    shape: tuple[int, ...]
+    cond_shape: ClassVar[None] = None
+    householder_vectors: Array
+    R_raw_diag: Array
+    R_upper: Array
+    R_tilde_raw_diag: Array
+    R_tilde_upper: Array
+    b: Array
+
+    def __init__(
+        self,
+        key: PRNGKeyArray,
+        shape: tuple[int, ...],
+        rank: int | None = None,
+        scale_init: float = 0.01,
+    ):
+        if len(shape) != 1:
+            raise ValueError("SylvesterFlow only supports 1D inputs.")
+        d = shape[0]
+        if rank is None:
+            rank = d
+        if not 1 <= rank <= d:
+            raise ValueError(f"rank must be in [1, {d}], got {rank}.")
+        m = rank
+        self.shape = shape
+        n_strict = m * (m - 1) // 2
+        k_hh, k_rd, k_ru, k_td, k_tu = jr.split(key, 5)
+        # Initialise Householder vectors away from zero to avoid degenerate norms
+        self.householder_vectors = (
+            jr.normal(k_hh, (m, d)) * scale_init + jnp.eye(m, d) * 1.0
+        )
+        self.R_raw_diag = jr.normal(k_rd, (m,)) * scale_init
+        self.R_upper = jr.normal(k_ru, (n_strict,)) * scale_init
+        self.R_tilde_raw_diag = jr.normal(k_td, (m,)) * scale_init
+        self.R_tilde_upper = jr.normal(k_tu, (n_strict,)) * scale_init
+        self.b = jnp.zeros((m,))
+
+    def _build_Q(self) -> Array:
+        """Householder-parametrised matrix with orthonormal columns (D, M)."""
+        d = self.shape[0]
+        m = self.householder_vectors.shape[0]
+        Q = jnp.eye(d)
+        for v in self.householder_vectors:
+            v = v / (jnp.linalg.norm(v) + 1e-12)
+            Q = Q - 2.0 * jnp.outer(v, v @ Q)
+        return Q[:, :m]
+
+    def _build_upper_triangular(self, diag: Array, strict_upper: Array) -> Array:
+        m = diag.shape[0]
+        R = jnp.diag(diag)
+        if m > 1:
+            upper_idx = jnp.triu_indices(m, k=1)
+            R = R.at[upper_idx].set(strict_upper)
+        return R
+
+    def _build_RR_tilde(self) -> tuple[Array, Array, Array, Array]:
+        # Constrain |diag(R) * diag(R_tilde)| < 1 for invertibility.
+        r_diag = jnp.tanh(self.R_raw_diag)
+        r_tilde_diag = jnp.tanh(self.R_tilde_raw_diag)
+        R = self._build_upper_triangular(r_diag, self.R_upper)
+        R_tilde = self._build_upper_triangular(r_tilde_diag, self.R_tilde_upper)
+        return R, R_tilde, r_diag, r_tilde_diag
+
+    def transform_and_log_det(self, x: ArrayLike, condition=None):
+        x = jnp.asarray(x)
+        Q = self._build_Q()
+        R, R_tilde, r_diag, r_tilde_diag = self._build_RR_tilde()
+        z = R @ (Q.T @ x) + self.b
+        y = x + Q @ (R_tilde @ jnp.tanh(z))
+        # Sylvester's identity: det(I_D + Q R_tilde diag(h') R Q^T)
+        # = det(I_M + R_tilde diag(h') R). Both R, R_tilde upper-triangular, so
+        # the result is upper-triangular with diagonal
+        # 1 + diag(R_tilde) * h'(z) * diag(R).
+        h_prime = 1.0 - jnp.tanh(z) ** 2
+        diag_term = 1.0 + r_tilde_diag * h_prime * r_diag
+        log_det = jnp.sum(jnp.log(jnp.abs(diag_term) + 1e-12))
+        return y, log_det
+
+    def inverse_and_log_det(self, y: ArrayLike, condition=None):
+        raise NotImplementedError(_NO_INVERSE_MSG.format(name="SylvesterFlow"))
+
+
+__all__ = [
+    "PlanarFlow",
+    "SylvesterFlow",
+]

--- a/src/gauss_flows/_src/transforms/classic.py
+++ b/src/gauss_flows/_src/transforms/classic.py
@@ -14,6 +14,7 @@ References:
 
 from typing import ClassVar
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 from flowjax.bijections import AbstractBijection
@@ -108,8 +109,10 @@ class SylvesterFlow(AbstractBijection):
         key: JAX random key.
         shape: Shape of the input ``(n_dims,)``.
         rank: Rank ``M`` of the flow. Defaults to the full input dim.
-        scale_init: Std of Gaussian init for the triangular strict upper
-            entries.
+        scale_init: Std of the Gaussian used to initialise the Householder
+            vectors (offset from the identity), the strict upper-triangular
+            entries of ``R`` and ``R_tilde``, and their raw diagonal
+            parameter vectors.
 
     Note:
         No algebraic inverse; ``inverse_and_log_det`` raises
@@ -153,15 +156,48 @@ class SylvesterFlow(AbstractBijection):
         self.R_tilde_upper = jr.normal(k_tu, (n_strict,)) * scale_init
         self.b = jnp.zeros((m,))
 
-    def _build_Q(self) -> Array:
-        """Householder-parametrised matrix with orthonormal columns (D, M)."""
-        d = self.shape[0]
+    def _q_transpose_apply(self, x: Array) -> Array:
+        """Compute ``Q.T @ x`` without materialising Q.
+
+        ``Q = (H_1 H_2 ... H_M) @ E`` where ``E = I_D[:, :M]`` selects the
+        first M columns. So ``Q.T @ x = E.T @ (H_M ... H_1) @ x``: apply
+        Householders ``H_1, ..., H_M`` in order, then take the leading M
+        components.
+        """
+
+        def body(carry, vec):
+            v_norm = vec / (jnp.linalg.norm(vec) + 1e-12)
+            return carry - 2.0 * v_norm * jnp.dot(v_norm, carry), None
+
+        result, _ = jax.lax.scan(body, x, self.householder_vectors)
         m = self.householder_vectors.shape[0]
-        Q = jnp.eye(d)
-        for v in self.householder_vectors:
-            v = v / (jnp.linalg.norm(v) + 1e-12)
-            Q = Q - 2.0 * jnp.outer(v, v @ Q)
-        return Q[:, :m]
+        return result[:m]
+
+    def _q_apply(self, v: Array) -> Array:
+        """Compute ``Q @ v`` without materialising Q.
+
+        Pad ``v`` (shape ``(M,)``) to ``D`` with zeros, then apply the
+        Householder reflections in reverse order.
+        """
+        d = self.shape[0]
+        w = jnp.zeros(d).at[: v.shape[0]].set(v)
+
+        def body(carry, vec):
+            v_norm = vec / (jnp.linalg.norm(vec) + 1e-12)
+            return carry - 2.0 * v_norm * jnp.dot(v_norm, carry), None
+
+        result, _ = jax.lax.scan(body, w, self.householder_vectors[::-1])
+        return result
+
+    def _build_Q(self) -> Array:
+        """Materialise ``Q`` as a ``(D, M)`` matrix.
+
+        Used by tests to verify orthonormality. The hot path
+        (``transform_and_log_det``) uses :meth:`_q_apply` /
+        :meth:`_q_transpose_apply` and never builds this matrix.
+        """
+        m = self.householder_vectors.shape[0]
+        return jax.vmap(self._q_apply, in_axes=1, out_axes=1)(jnp.eye(m))
 
     def _build_upper_triangular(self, diag: Array, strict_upper: Array) -> Array:
         m = diag.shape[0]
@@ -181,10 +217,9 @@ class SylvesterFlow(AbstractBijection):
 
     def transform_and_log_det(self, x: ArrayLike, condition=None):
         x = jnp.asarray(x)
-        Q = self._build_Q()
         R, R_tilde, r_diag, r_tilde_diag = self._build_RR_tilde()
-        z = R @ (Q.T @ x) + self.b
-        y = x + Q @ (R_tilde @ jnp.tanh(z))
+        z = R @ self._q_transpose_apply(x) + self.b
+        y = x + self._q_apply(R_tilde @ jnp.tanh(z))
         # Sylvester's identity: det(I_D + Q R_tilde diag(h') R Q^T)
         # = det(I_M + R_tilde diag(h') R). Both R, R_tilde upper-triangular, so
         # the result is upper-triangular with diagonal

--- a/tests/test_transforms_classic.py
+++ b/tests/test_transforms_classic.py
@@ -1,0 +1,101 @@
+"""Tests for classic (VI-only) planar and Sylvester normalizing flow bijections."""
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from gauss_flows import PlanarFlow, SylvesterFlow
+
+
+def _log_det_from_jacobian(fn, x):
+    """Reference log-abs-det via explicit Jacobian of fn at x."""
+    J = jax.jacobian(fn)(x)
+    return jnp.log(jnp.abs(jnp.linalg.det(J)))
+
+
+def test_planar_log_det_matches_jacobian(key):
+    shape = (5,)
+    k_init, k_x = jr.split(key)
+    flow = PlanarFlow(k_init, shape=shape, scale_init=0.3)
+    x = jr.normal(k_x, shape)
+    _, log_det = flow.transform_and_log_det(x)
+    expected = _log_det_from_jacobian(lambda z: flow.transform_and_log_det(z)[0], x)
+    assert jnp.allclose(log_det, expected, atol=1e-5)
+
+
+def test_planar_shape(key):
+    shape = (4,)
+    flow = PlanarFlow(key, shape=shape)
+    x = jr.normal(jr.fold_in(key, 1), shape)
+    y, log_det = flow.transform_and_log_det(x)
+    assert y.shape == shape
+    assert log_det.shape == ()
+
+
+def test_planar_inverse_raises(key):
+    flow = PlanarFlow(key, shape=(3,))
+    y = jnp.zeros((3,))
+    with pytest.raises(NotImplementedError, match="PlanarFlow"):
+        flow.inverse_and_log_det(y)
+
+
+def test_planar_invertibility_projection_keeps_det_positive(key):
+    """u_hat projection ensures 1 + u_hat.w * (1 - tanh²) >= 0."""
+    shape = (4,)
+    # Force |u|, |w| large to exercise the projection
+    flow = PlanarFlow(key, shape=shape, scale_init=5.0)
+    x = jr.normal(jr.fold_in(key, 2), shape)
+    _, log_det = flow.transform_and_log_det(x)
+    assert jnp.isfinite(log_det)
+
+
+def test_sylvester_log_det_matches_jacobian_full_rank(key):
+    shape = (5,)
+    k_init, k_x = jr.split(key)
+    flow = SylvesterFlow(k_init, shape=shape, rank=5, scale_init=0.3)
+    x = jr.normal(k_x, shape)
+    _, log_det = flow.transform_and_log_det(x)
+    expected = _log_det_from_jacobian(lambda z: flow.transform_and_log_det(z)[0], x)
+    assert jnp.allclose(log_det, expected, atol=1e-5)
+
+
+def test_sylvester_log_det_matches_jacobian_low_rank(key):
+    shape = (6,)
+    k_init, k_x = jr.split(key)
+    flow = SylvesterFlow(k_init, shape=shape, rank=3, scale_init=0.3)
+    x = jr.normal(k_x, shape)
+    _, log_det = flow.transform_and_log_det(x)
+    expected = _log_det_from_jacobian(lambda z: flow.transform_and_log_det(z)[0], x)
+    assert jnp.allclose(log_det, expected, atol=1e-5)
+
+
+def test_sylvester_shape(key):
+    shape = (4,)
+    flow = SylvesterFlow(key, shape=shape, rank=2)
+    x = jr.normal(jr.fold_in(key, 1), shape)
+    y, log_det = flow.transform_and_log_det(x)
+    assert y.shape == shape
+    assert log_det.shape == ()
+
+
+def test_sylvester_inverse_raises(key):
+    flow = SylvesterFlow(key, shape=(3,))
+    y = jnp.zeros((3,))
+    with pytest.raises(NotImplementedError, match="SylvesterFlow"):
+        flow.inverse_and_log_det(y)
+
+
+def test_sylvester_rank_bounds(key):
+    with pytest.raises(ValueError, match="rank"):
+        SylvesterFlow(key, shape=(3,), rank=0)
+    with pytest.raises(ValueError, match="rank"):
+        SylvesterFlow(key, shape=(3,), rank=4)
+
+
+def test_sylvester_Q_orthonormal_columns(key):
+    shape = (6,)
+    flow = SylvesterFlow(key, shape=shape, rank=3, scale_init=0.5)
+    Q = flow._build_Q()
+    assert Q.shape == (6, 3)
+    assert jnp.allclose(Q.T @ Q, jnp.eye(3), atol=1e-5)

--- a/tests/test_transforms_classic.py
+++ b/tests/test_transforms_classic.py
@@ -9,9 +9,13 @@ from gauss_flows import PlanarFlow, SylvesterFlow
 
 
 def _log_det_from_jacobian(fn, x):
-    """Reference log-abs-det via explicit Jacobian of fn at x."""
+    """Reference log-abs-det via explicit Jacobian of fn at x.
+
+    Uses ``slogdet`` rather than ``log(abs(det))`` so the test reference is
+    numerically stable even when det is very small or very large.
+    """
     J = jax.jacobian(fn)(x)
-    return jnp.log(jnp.abs(jnp.linalg.det(J)))
+    return jnp.linalg.slogdet(J)[1]
 
 
 def test_planar_log_det_matches_jacobian(key):
@@ -41,13 +45,26 @@ def test_planar_inverse_raises(key):
 
 
 def test_planar_invertibility_projection_keeps_det_positive(key):
-    """u_hat projection ensures 1 + u_hat.w * (1 - tanh²) >= 0."""
+    """u_hat projection ensures the planar Jacobian determinant stays positive.
+
+    The projection enforces ``w . u_hat >= -1``, which keeps
+    ``1 + (1 - tanh^2(a)) * (u_hat . w)`` non-negative — i.e. the Jacobian
+    determinant cannot flip sign. We verify this directly rather than just
+    checking ``isfinite(log_det)`` (which would pass even if the
+    implementation took ``abs`` of a negative determinant).
+    """
     shape = (4,)
-    # Force |u|, |w| large to exercise the projection
+    # Large init exercises the projection (without it, w . u could be < -1).
     flow = PlanarFlow(key, shape=shape, scale_init=5.0)
     x = jr.normal(jr.fold_in(key, 2), shape)
     _, log_det = flow.transform_and_log_det(x)
-    assert jnp.isfinite(log_det)
+
+    jacobian = jax.jacobian(lambda z: flow.transform_and_log_det(z)[0])(x)
+    det = jnp.linalg.det(jacobian)
+    assert det > 0
+    assert jnp.allclose(log_det, jnp.log(det), atol=1e-5)
+    # Independently check the algebraic invertibility condition.
+    assert jnp.dot(flow.w, flow._u_hat()) >= -1.0
 
 
 def test_sylvester_log_det_matches_jacobian_full_rank(key):


### PR DESCRIPTION
## Summary

- **PlanarFlow** (Rezende & Mohamed 2015): \`y = x + u_hat * tanh(w . x + b)\` with the \`u_hat\` projection that enforces \`w . u_hat >= -1\` (the original-paper invertibility condition).
- **SylvesterFlow** (van den Berg et al. 2018): rank-\`M\` generalisation with \`Q in R^{D x M}\` parametrised by Householder reflections, \`R\` and \`R_tilde\` upper-triangular with diagonals constrained via \`tanh\`. Log-det collapses to a sum over \`M\` diagonal entries via Sylvester's identity.
- Both flows live in the new \`transforms/classic.py\` and are exported from the top level.
- Both flows raise \`NotImplementedError\` on \`inverse_and_log_det\` — they are usable only in the generative direction. Document this and point users at \`Transformed.sample_and_log_prob\` for VI.

Out of scope (deferrable to follow-up): \`RadialFlow\` and \`TriangularSylvesterFlow\`.

Closes #35.

## Test plan

- [x] \`uv run pytest tests/test_transforms_classic.py -v\` — 10 new tests pass: log-det matches \`jax.jacobian\` reference at 1e-5 (Planar; Sylvester full-rank and low-rank), shape, \`NotImplementedError\` on inverse, \`Q^T Q = I\` for the Sylvester Q, large-init invertibility projection, rank bounds.
- [x] \`uv run pytest -q\` — full suite (64 tests) green.
- [x] \`uv run --group lint ruff check .\` + \`ruff format --check .\` — clean.
- [x] \`uv run --group typecheck ty check src/gauss_flows\` — clean.

A demo notebook (8-Planar stack on TwoMoons) is left for the docs PR (#15) where it fits naturally with the surjection notebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)