### PR TITLE
feat(pr-9): add GaussianMixture base distribution

### DIFF
--- a/src/gauss_flows/__init__.py
+++ b/src/gauss_flows/__init__.py
@@ -3,6 +3,9 @@
 Public API re-exported from the private _src/ implementation directory.
 """
 
+from gauss_flows._src.distributions import (
+    GaussianMixture,
+)
 from gauss_flows._src.flows import (
     coupling_gaussianization_flow,
     gaussianization_flow,
@@ -45,6 +48,7 @@ __all__ = [
     "FixedRotation",
     "FlowDist",
     "FlowGuide",
+    "GaussianMixture",
     "HaarWavelet",
     "HouseholderRotation",
     "InverseGaussCDF",

--- a/src/gauss_flows/_src/distributions/__init__.py
+++ b/src/gauss_flows/_src/distributions/__init__.py
@@ -1,0 +1,8 @@
+"""Trainable base distributions for Gaussianization and SurVAE flows."""
+
+from gauss_flows._src.distributions.mixture import GaussianMixture
+
+
+__all__ = [
+    "GaussianMixture",
+]

--- a/src/gauss_flows/_src/distributions/mixture.py
+++ b/src/gauss_flows/_src/distributions/mixture.py
@@ -1,0 +1,132 @@
+"""Trainable Gaussian mixture base distribution.
+
+Natural companion to :class:`MixtureGaussianCDF` (the marginal transform):
+provides a joint multi-modal base for Gaussianization pipelines on targets
+that are multi-modal or fat-tailed.
+"""
+
+from typing import ClassVar
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy.stats as jstats
+from flowjax.distributions import AbstractDistribution
+from jax import Array
+from jax.scipy.special import logsumexp
+from jaxtyping import PRNGKeyArray
+
+
+class GaussianMixture(AbstractDistribution):
+    """Trainable multivariate Gaussian Mixture Model base distribution.
+
+    Parameterises a ``K``-component mixture of ``D``-dimensional Gaussians
+    with trainable component means, scales, and weights. Supports a
+    diagonal covariance parameterisation (scale per component per dim)
+    and a full-covariance Cholesky parameterisation.
+
+    Args:
+        key: JAX random key used to initialise the component means.
+        n_components: Number of mixture components ``K``.
+        event_shape: Shape of a single sample ``(D,)``.
+        diagonal: If True (default), diagonal covariance via ``log_scale``.
+            If False, full covariance via a per-component lower-triangular
+            Cholesky factor.
+        loc_init_scale: Std of the Gaussian used to initialise component means.
+        log_scale_init: Initial value of ``log_scale`` (resp. Cholesky
+            log-diagonal for ``diagonal=False``). Defaults to ``0.0``
+            (unit scale at init).
+
+    The event shape is stored as ``self.shape`` per the flowjax
+    distribution contract. Uniform initial mixing weights.
+    """
+
+    n_components: int = eqx.field(static=True)
+    diagonal: bool = eqx.field(static=True)
+    shape: tuple[int, ...]
+    cond_shape: ClassVar[None] = None
+    loc: Array
+    log_scale: Array
+    strict_tril: Array
+    log_weights: Array
+
+    def __init__(
+        self,
+        key: PRNGKeyArray,
+        n_components: int,
+        event_shape: tuple[int, ...],
+        *,
+        diagonal: bool = True,
+        loc_init_scale: float = 1.0,
+        log_scale_init: float = 0.0,
+    ):
+        if n_components <= 0:
+            raise ValueError(f"n_components must be positive, got {n_components}.")
+        if len(event_shape) != 1:
+            raise ValueError("GaussianMixture only supports 1D event shapes.")
+        d = event_shape[0]
+        k = n_components
+        self.n_components = k
+        self.diagonal = diagonal
+        self.shape = event_shape
+        self.loc = jr.normal(key, (k, d)) * loc_init_scale
+        self.log_scale = jnp.full((k, d), log_scale_init)
+        n_strict = d * (d - 1) // 2
+        self.strict_tril = (
+            jnp.zeros((k, n_strict)) if not diagonal else jnp.zeros((k, 0))
+        )
+        self.log_weights = jnp.zeros((k,))
+
+    def _build_L(self) -> Array:
+        """Build component Cholesky factors ``L`` of shape ``(K, D, D)``.
+
+        For ``diagonal=True`` this is simply ``diag(exp(log_scale))``.
+        For ``diagonal=False``, the positive diagonal comes from
+        ``exp(log_scale)`` and the strict lower triangle from
+        ``strict_tril``.
+        """
+        d = self.log_scale.shape[1]
+        diag_scale = jnp.exp(self.log_scale)
+        L_diag = jax.vmap(jnp.diag)(diag_scale)
+        if self.diagonal:
+            return L_diag
+        # Scatter strict_tril into the strict lower triangle of each (D, D) block.
+        idx = jnp.tril_indices(d, k=-1)
+
+        def _fill(block, strict):
+            return block.at[idx].set(strict)
+
+        return jax.vmap(_fill)(L_diag, self.strict_tril)
+
+    def _log_prob(self, x: Array, condition: Array | None = None) -> Array:
+        log_weights = jax.nn.log_softmax(self.log_weights)
+        if self.diagonal:
+            scales = jnp.exp(self.log_scale)
+            # jstats.norm.logpdf broadcasts (D,) vs (K, D) -> (K, D); sum last axis.
+            log_pdfs = jnp.sum(
+                jstats.norm.logpdf(x[None, :], self.loc, scales), axis=-1
+            )
+        else:
+            L = self._build_L()
+
+            def _component_logpdf(loc_k: Array, L_k: Array) -> Array:
+                diff = x - loc_k
+                z = jax.scipy.linalg.solve_triangular(L_k, diff, lower=True)
+                d = diff.shape[0]
+                log_det = jnp.sum(jnp.log(jnp.diag(L_k)))
+                return -0.5 * d * jnp.log(2.0 * jnp.pi) - log_det - 0.5 * jnp.sum(z**2)
+
+            log_pdfs = jax.vmap(_component_logpdf)(self.loc, L)
+        return logsumexp(log_weights + log_pdfs)
+
+    def _sample(self, key: PRNGKeyArray, condition: Array | None = None) -> Array:
+        k_comp, k_normal = jr.split(key)
+        weights = jax.nn.softmax(self.log_weights)
+        component = jr.choice(k_comp, self.n_components, p=weights)
+        z = jr.normal(k_normal, self.shape)
+        if self.diagonal:
+            scale = jnp.exp(self.log_scale[component])
+            return self.loc[component] + scale * z
+        L = self._build_L()[component]
+        return self.loc[component] + L @ z

--- a/src/gauss_flows/_src/flows.py
+++ b/src/gauss_flows/_src/flows.py
@@ -9,7 +9,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 from flowjax.bijections import Chain, Flip, Invert, Permute, Scan
-from flowjax.distributions import Normal, Transformed
+from flowjax.distributions import AbstractDistribution, Normal, Transformed
 from jaxtyping import PRNGKeyArray
 
 from gauss_flows._src.transforms.coupling import RQSplineCoupling
@@ -25,6 +25,7 @@ def gaussianization_flow(
     n_components: int = 8,
     rotation: str = "householder",
     n_reflections: int | None = None,
+    base_dist: AbstractDistribution | None = None,
 ) -> Transformed:
     """Construct a Gaussianization flow.
 
@@ -41,6 +42,8 @@ def gaussianization_flow(
             Defaults to "householder".
         n_reflections: Number of Householder reflections (only for "householder").
             Defaults to n_dims.
+        base_dist: Optional base distribution override (must have event
+            shape ``(n_dims,)``). Defaults to a standard ``Normal``.
 
     Returns:
         A flowjax Transformed distribution.
@@ -49,7 +52,12 @@ def gaussianization_flow(
         n_reflections = n_dims
 
     shape = (n_dims,)
-    base_dist = Normal(jnp.zeros(n_dims))
+    if base_dist is None:
+        base_dist = Normal(jnp.zeros(n_dims))
+    elif base_dist.shape != shape:
+        raise ValueError(
+            f"base_dist.shape {base_dist.shape} does not match (n_dims,) = {shape}."
+        )
 
     def make_layer(key):
         marginal = MixtureGaussianCDF(n_components=n_components, shape=shape)

--- a/src/gauss_flows/_src/flows.py
+++ b/src/gauss_flows/_src/flows.py
@@ -54,10 +54,17 @@ def gaussianization_flow(
     shape = (n_dims,)
     if base_dist is None:
         base_dist = Normal(jnp.zeros(n_dims))
-    elif base_dist.shape != shape:
-        raise ValueError(
-            f"base_dist.shape {base_dist.shape} does not match (n_dims,) = {shape}."
-        )
+    else:
+        if base_dist.shape != shape:
+            raise ValueError(
+                f"base_dist.shape {base_dist.shape} does not match (n_dims,) = {shape}."
+            )
+        if base_dist.cond_shape is not None:
+            raise ValueError(
+                "Conditional base distributions are not supported by "
+                "gaussianization_flow (no condition is threaded through). "
+                f"Got base_dist with cond_shape={base_dist.cond_shape}."
+            )
 
     def make_layer(key):
         marginal = MixtureGaussianCDF(n_components=n_components, shape=shape)

--- a/tests/test_distributions_mixture.py
+++ b/tests/test_distributions_mixture.py
@@ -1,0 +1,147 @@
+"""Tests for the GaussianMixture trainable base distribution."""
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy.stats as jstats
+import pytest
+from jax.scipy.special import logsumexp
+
+from gauss_flows import GaussianMixture, gaussianization_flow
+
+
+def _reference_log_prob(dist: GaussianMixture, x):
+    """Oracle GMM log-prob via jstats.multivariate_normal.logpdf."""
+    log_weights = jax.nn.log_softmax(dist.log_weights)
+    L = dist._build_L()
+
+    def _component(loc_k, L_k):
+        Sigma = L_k @ L_k.T
+        return jstats.multivariate_normal.logpdf(x, loc_k, Sigma)
+
+    log_pdfs = jax.vmap(_component)(dist.loc, L)
+    return logsumexp(log_weights + log_pdfs)
+
+
+def test_diagonal_sample_shape(key):
+    dist = GaussianMixture(key, n_components=3, event_shape=(4,))
+    samples = dist.sample(jr.fold_in(key, 1), sample_shape=(8,))
+    assert samples.shape == (8, 4)
+    assert jnp.all(jnp.isfinite(samples))
+
+
+def test_full_sample_shape(key):
+    dist = GaussianMixture(key, n_components=3, event_shape=(4,), diagonal=False)
+    samples = dist.sample(jr.fold_in(key, 1), sample_shape=(8,))
+    assert samples.shape == (8, 4)
+    assert jnp.all(jnp.isfinite(samples))
+
+
+def test_diagonal_log_prob_matches_reference(key):
+    dist = GaussianMixture(key, n_components=3, event_shape=(4,))
+    x = jr.normal(jr.fold_in(key, 1), (4,))
+    actual = dist.log_prob(x)
+    expected = _reference_log_prob(dist, x)
+    assert jnp.allclose(actual, expected, atol=1e-5)
+
+
+def test_full_log_prob_matches_reference(key):
+    dist = GaussianMixture(key, n_components=3, event_shape=(4,), diagonal=False)
+    # Give strict_tril non-zero entries to exercise off-diagonal terms.
+    new_strict = jr.normal(jr.fold_in(key, 2), dist.strict_tril.shape) * 0.3
+    dist = eqx.tree_at(lambda d: d.strict_tril, dist, new_strict)
+
+    x = jr.normal(jr.fold_in(key, 3), (4,))
+    actual = dist.log_prob(x)
+    expected = _reference_log_prob(dist, x)
+    assert jnp.allclose(actual, expected, atol=1e-5)
+
+
+def test_sample_log_prob_roundtrip_finite(key):
+    dist = GaussianMixture(key, n_components=3, event_shape=(3,))
+    samples = dist.sample(jr.fold_in(key, 1), sample_shape=(16,))
+    log_probs = dist.log_prob(samples)
+    assert log_probs.shape == (16,)
+    assert jnp.all(jnp.isfinite(log_probs))
+
+
+def test_weights_respected(key):
+    """Heavy-weighted component should dominate a sample-based estimate."""
+    dist = GaussianMixture(key, n_components=2, event_shape=(2,))
+    # Pin locs far apart so the nearest-component assignment is unambiguous.
+    dist = eqx.tree_at(lambda d: d.loc, dist, jnp.array([[-10.0, 0.0], [10.0, 0.0]]))
+    # Skew weights strongly toward component 0.
+    dist = eqx.tree_at(lambda d: d.log_weights, dist, jnp.array([5.0, -5.0]))
+    samples = dist.sample(jr.fold_in(key, 1), sample_shape=(2000,))
+    d0 = jnp.linalg.norm(samples - dist.loc[0], axis=-1)
+    d1 = jnp.linalg.norm(samples - dist.loc[1], axis=-1)
+    fraction_near_c0 = jnp.mean(d0 < d1)
+    assert fraction_near_c0 > 0.95
+
+
+def test_fits_known_gmm_via_log_prob_improvement(key):
+    """Crude fit test: after a few steps of max-likelihood the model should
+    assign strictly higher average log-prob than a poorly-initialised one.
+    Avoids a full optimisation dependency; we just check local improvement.
+    """
+    target_locs = jnp.array([[-3.0, 0.0], [3.0, 0.0]])
+    n = 500
+    k_sample = jr.fold_in(key, 1)
+    comp = jr.bernoulli(k_sample, 0.5, (n,)).astype(jnp.int32)
+    noise = jr.normal(jr.fold_in(key, 2), (n, 2)) * 0.5
+    data = target_locs[comp] + noise
+
+    init = GaussianMixture(key, n_components=2, event_shape=(2,), loc_init_scale=3.0)
+
+    # Fit locs directly to empirical means for each component under hard
+    # assignment. This is a single-step E/M, good enough to beat init.
+    def hard_assign(d):
+        L = d._build_L()
+
+        def _component(loc_k, L_k):
+            Sigma = L_k @ L_k.T
+            return jstats.multivariate_normal.logpdf(data, loc_k, Sigma)
+
+        log_pdfs = jax.vmap(_component)(d.loc, L)
+        return jnp.argmax(log_pdfs, axis=0)
+
+    assign = hard_assign(init)
+    new_loc = jnp.stack(
+        [
+            jnp.mean(data[assign == 0], axis=0),
+            jnp.mean(data[assign == 1], axis=0),
+        ]
+    )
+    fitted = eqx.tree_at(lambda d: d.loc, init, new_loc)
+    mean_lp_init = jnp.mean(init.log_prob(data))
+    mean_lp_fit = jnp.mean(fitted.log_prob(data))
+    assert mean_lp_fit > mean_lp_init + 0.1
+
+
+def test_as_base_dist_in_gaussianization_flow(key):
+    k_base, k_flow, k_sample = jr.split(key, 3)
+    base = GaussianMixture(k_base, n_components=3, event_shape=(3,))
+    flow = gaussianization_flow(k_flow, n_dims=3, n_layers=2, base_dist=base)
+    samples = flow.sample(k_sample, (8,))
+    log_probs = flow.log_prob(samples)
+    assert samples.shape == (8, 3)
+    assert log_probs.shape == (8,)
+    assert jnp.all(jnp.isfinite(log_probs))
+
+
+def test_event_shape_mismatch_raises(key):
+    k_base, k_flow = jr.split(key)
+    base = GaussianMixture(k_base, n_components=2, event_shape=(4,))
+    with pytest.raises(ValueError, match=r"base_dist\.shape"):
+        gaussianization_flow(k_flow, n_dims=3, n_layers=2, base_dist=base)
+
+
+def test_n_components_must_be_positive(key):
+    with pytest.raises(ValueError, match="n_components"):
+        GaussianMixture(key, n_components=0, event_shape=(2,))
+
+
+def test_only_1d_event_shape(key):
+    with pytest.raises(ValueError, match="1D event"):
+        GaussianMixture(key, n_components=2, event_shape=(2, 3))

--- a/tests/test_distributions_mixture.py
+++ b/tests/test_distributions_mixture.py
@@ -107,10 +107,19 @@ def test_fits_known_gmm_via_log_prob_improvement(key):
         return jnp.argmax(log_pdfs, axis=0)
 
     assign = hard_assign(init)
+
+    # Guard against empty assignments: keep the prior loc for any component
+    # that received zero points (otherwise jnp.mean of an empty slice is NaN
+    # and the test fails for reasons unrelated to GaussianMixture itself).
+    def _safe_mean(mask, prior_loc):
+        count = jnp.sum(mask)
+        masked_sum = jnp.sum(jnp.where(mask[:, None], data, 0.0), axis=0)
+        return jnp.where(count > 0, masked_sum / jnp.maximum(count, 1), prior_loc)
+
     new_loc = jnp.stack(
         [
-            jnp.mean(data[assign == 0], axis=0),
-            jnp.mean(data[assign == 1], axis=0),
+            _safe_mean(assign == 0, init.loc[0]),
+            _safe_mean(assign == 1, init.loc[1]),
         ]
     )
     fitted = eqx.tree_at(lambda d: d.loc, init, new_loc)
@@ -135,6 +144,23 @@ def test_event_shape_mismatch_raises(key):
     base = GaussianMixture(k_base, n_components=2, event_shape=(4,))
     with pytest.raises(ValueError, match=r"base_dist\.shape"):
         gaussianization_flow(k_flow, n_dims=3, n_layers=2, base_dist=base)
+
+
+def test_conditional_base_dist_raises(key):
+    """gaussianization_flow doesn't thread a condition, so reject conditional bases."""
+
+    # Forge a conditional version of GaussianMixture by overriding cond_shape
+    # at the class level in a tiny subclass — easier than building a full
+    # conditional distribution from scratch.
+    class _ConditionalMixture(GaussianMixture):
+        cond_shape: tuple[int, ...] | None = (1,)  # type: ignore[assignment]
+
+    conditional = _ConditionalMixture(key, n_components=2, event_shape=(3,))
+    assert conditional.cond_shape == (1,)
+    with pytest.raises(ValueError, match="Conditional base distributions"):
+        gaussianization_flow(
+            jr.fold_in(key, 1), n_dims=3, n_layers=2, base_dist=conditional
+        )
 
 
 def test_n_components_must_be_positive(key):


### PR DESCRIPTION
## Summary

- New \`GaussianMixture\` base distribution under \`_src/distributions/mixture.py\` — trainable \`K\`-component mixture of \`D\`-dim Gaussians. Parameterises component \`loc\`, per-dim \`log_scale\`, and \`log_weights\` (softmaxed). Full-covariance variant stores the strict-lower triangle of the component Cholesky factors; the diagonal comes from \`exp(log_scale)\`.
- \`_sample\` / \`_log_prob\` / \`shape\` / \`cond_shape\` wired per flowjax's \`AbstractDistribution\` contract, so \`GaussianMixture\` is a drop-in base for \`Transformed\`.
- \`gaussianization_flow\` grows an optional \`base_dist\` override. Validates event-shape match, defaults to a standard \`Normal\` when unspecified.
- New \`_src/distributions/\` package with \`__init__.py\` so future base distributions (GaussianPCA, etc.) have a natural home.

Closes #21.

## Test plan

- [x] \`uv run pytest tests/test_distributions_mixture.py -v\` — 11 new tests: sample shape (diag + full), log-prob matches a \`jstats.multivariate_normal.logpdf\` oracle at 1e-5 (diag + full with non-zero strict lower tril), sample/log-prob finiteness roundtrip, heavy-weight component dominates, single-step EM beats random init, drop-in as base in \`gaussianization_flow\`, event-shape mismatch raises, \`n_components>0\` validation, 1D-only event-shape validation.
- [x] \`uv run pytest -q\` — full suite (65 tests) green.
- [x] \`uv run --group lint ruff check .\` + \`ruff format --check .\` — clean.
- [x] \`uv run --group typecheck ty check src/gauss_flows\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)