### PR TITLE
feat(pr-10): add GaussianPCA base distribution

### DIFF
--- a/src/gauss_flows/__init__.py
+++ b/src/gauss_flows/__init__.py
@@ -5,6 +5,7 @@ Public API re-exported from the private _src/ implementation directory.
 
 from gauss_flows._src.distributions import (
     GaussianMixture,
+    GaussianPCA,
 )
 from gauss_flows._src.flows import (
     coupling_gaussianization_flow,
@@ -52,6 +53,7 @@ __all__ = [
     "FlowDist",
     "FlowGuide",
     "GaussianMixture",
+    "GaussianPCA",
     "HaarWavelet",
     "HouseholderRotation",
     "InverseGaussCDF",

--- a/src/gauss_flows/_src/distributions/__init__.py
+++ b/src/gauss_flows/_src/distributions/__init__.py
@@ -1,8 +1,10 @@
 """Trainable base distributions for Gaussianization and SurVAE flows."""
 
 from gauss_flows._src.distributions.mixture import GaussianMixture
+from gauss_flows._src.distributions.pca import GaussianPCA
 
 
 __all__ = [
     "GaussianMixture",
+    "GaussianPCA",
 ]

--- a/src/gauss_flows/_src/distributions/pca.py
+++ b/src/gauss_flows/_src/distributions/pca.py
@@ -1,0 +1,95 @@
+"""Probabilistic-PCA base distribution (low-rank + diagonal Gaussian).
+
+Parameterises ``Sigma = W W^T + sigma^2 I`` with ``W in R^{D x K}`` via
+:class:`GaussianPCA`. ``O(DK)`` parameters and ``O(DK)`` sampling via the
+reparametrisation ``x = loc + W z + sigma eps``. Log-prob uses the
+Woodbury identity / matrix-determinant lemma so inversion and
+log-determinant stay ``O(K^3)`` + ``O(DK)`` rather than ``O(D^3)``.
+
+Reference: Tipping & Bishop 1999, *Probabilistic Principal Component
+Analysis*.
+"""
+
+from typing import ClassVar
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from flowjax.distributions import AbstractDistribution
+from jax import Array
+from jaxtyping import ArrayLike, PRNGKeyArray
+
+
+class GaussianPCA(AbstractDistribution):
+    """Probabilistic-PCA Gaussian base distribution.
+
+    ``x ~ N(loc, W W^T + sigma^2 I)`` with ``W in R^{D x K}``.
+
+    Args:
+        key: JAX random key used to initialise ``W``.
+        event_shape: Shape of a single sample ``(D,)``.
+        latent_dim: Rank ``K``.
+        loc: Mean vector. Scalar is broadcast to shape ``(D,)``.
+        log_sigma_init: Initial value of ``log(sigma)``.
+        W_init_scale: Std of the Gaussian used to initialise ``W``.
+    """
+
+    latent_dim: int = eqx.field(static=True)
+    shape: tuple[int, ...]
+    cond_shape: ClassVar[None] = None
+    loc: Array
+    W: Array
+    log_sigma: Array
+
+    def __init__(
+        self,
+        key: PRNGKeyArray,
+        event_shape: tuple[int, ...],
+        latent_dim: int,
+        *,
+        loc: ArrayLike = 0.0,
+        log_sigma_init: float = 0.0,
+        W_init_scale: float = 0.1,
+    ):
+        if len(event_shape) != 1:
+            raise ValueError("GaussianPCA only supports 1D event shapes.")
+        d = event_shape[0]
+        if not 1 <= latent_dim <= d:
+            raise ValueError(f"latent_dim must be in [1, {d}], got {latent_dim}.")
+        self.latent_dim = latent_dim
+        self.shape = event_shape
+        self.loc = jnp.broadcast_to(jnp.asarray(loc, dtype=float), event_shape)
+        self.W = jr.normal(key, (d, latent_dim)) * W_init_scale
+        self.log_sigma = jnp.asarray(log_sigma_init, dtype=float)
+
+    def covariance(self) -> Array:
+        """Return the explicit ``D x D`` covariance ``W W^T + sigma^2 I``."""
+        sigma2 = jnp.exp(2.0 * self.log_sigma)
+        return self.W @ self.W.T + sigma2 * jnp.eye(self.shape[0])
+
+    def _sample(self, key: PRNGKeyArray, condition: Array | None = None) -> Array:
+        k_z, k_eps = jr.split(key)
+        z = jr.normal(k_z, (self.latent_dim,))
+        eps = jr.normal(k_eps, self.shape)
+        sigma = jnp.exp(self.log_sigma)
+        return self.loc + self.W @ z + sigma * eps
+
+    def _log_prob(self, x: Array, condition: Array | None = None) -> Array:
+        d = self.shape[0]
+        k = self.latent_dim
+        sigma2 = jnp.exp(2.0 * self.log_sigma)
+        diff = x - self.loc
+        # Small K x K capacitance matrix from the Woodbury identity.
+        M = sigma2 * jnp.eye(k) + self.W.T @ self.W
+        L = jnp.linalg.cholesky(M)
+        Wt_diff = self.W.T @ diff
+        y = jax.scipy.linalg.cho_solve((L, True), Wt_diff)
+        # Sigma^-1 (x - loc) via Woodbury:
+        #   quadratic = sigma^-2 * ||diff||^2 - sigma^-4 * (W^T diff)^T M^-1 (W^T diff).
+        quad = jnp.sum(diff**2) / sigma2 - (Wt_diff @ y) / (sigma2**2)
+        # Matrix determinant lemma:
+        #   log|Sigma| = 2(D-K) log sigma + log|M|.
+        log_det_M = 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
+        log_det = 2.0 * (d - k) * self.log_sigma + log_det_M
+        return -0.5 * (d * jnp.log(2.0 * jnp.pi) + log_det + quad)

--- a/src/gauss_flows/_src/distributions/pca.py
+++ b/src/gauss_flows/_src/distributions/pca.py
@@ -33,9 +33,16 @@ class GaussianPCA(AbstractDistribution):
         loc: Mean vector. Scalar is broadcast to shape ``(D,)``.
         log_sigma_init: Initial value of ``log(sigma)``.
         W_init_scale: Std of the Gaussian used to initialise ``W``.
+        eps: Numerical floor added to ``sigma^2`` so the Cholesky of the
+            ``K x K`` capacitance matrix stays well-defined and the
+            Woodbury quadratic stays finite even if ``log_sigma`` drifts
+            very negative during training. Default ``1e-12`` is far below
+            any reasonable target variance and does not affect gradients
+            in the well-conditioned regime.
     """
 
     latent_dim: int = eqx.field(static=True)
+    eps: float = eqx.field(static=True)
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
     loc: Array
@@ -51,34 +58,46 @@ class GaussianPCA(AbstractDistribution):
         loc: ArrayLike = 0.0,
         log_sigma_init: float = 0.0,
         W_init_scale: float = 0.1,
+        eps: float = 1e-12,
     ):
         if len(event_shape) != 1:
             raise ValueError("GaussianPCA only supports 1D event shapes.")
         d = event_shape[0]
         if not 1 <= latent_dim <= d:
             raise ValueError(f"latent_dim must be in [1, {d}], got {latent_dim}.")
+        if eps < 0:
+            raise ValueError(f"eps must be non-negative, got {eps}.")
         self.latent_dim = latent_dim
+        self.eps = eps
         self.shape = event_shape
         self.loc = jnp.broadcast_to(jnp.asarray(loc, dtype=float), event_shape)
         self.W = jr.normal(key, (d, latent_dim)) * W_init_scale
         self.log_sigma = jnp.asarray(log_sigma_init, dtype=float)
 
+    def _sigma2(self) -> Array:
+        """Variance with a small floor so it cannot underflow to zero.
+
+        Adding ``eps`` to ``exp(2*log_sigma)`` keeps the Woodbury quadratic
+        finite and the capacitance matrix ``M`` strictly PD even if
+        ``log_sigma`` drifts very negative during training.
+        """
+        return jnp.exp(2.0 * self.log_sigma) + self.eps
+
     def covariance(self) -> Array:
         """Return the explicit ``D x D`` covariance ``W W^T + sigma^2 I``."""
-        sigma2 = jnp.exp(2.0 * self.log_sigma)
-        return self.W @ self.W.T + sigma2 * jnp.eye(self.shape[0])
+        return self.W @ self.W.T + self._sigma2() * jnp.eye(self.shape[0])
 
     def _sample(self, key: PRNGKeyArray, condition: Array | None = None) -> Array:
         k_z, k_eps = jr.split(key)
         z = jr.normal(k_z, (self.latent_dim,))
-        eps = jr.normal(k_eps, self.shape)
-        sigma = jnp.exp(self.log_sigma)
-        return self.loc + self.W @ z + sigma * eps
+        eps_noise = jr.normal(k_eps, self.shape)
+        sigma = jnp.sqrt(self._sigma2())
+        return self.loc + self.W @ z + sigma * eps_noise
 
     def _log_prob(self, x: Array, condition: Array | None = None) -> Array:
         d = self.shape[0]
         k = self.latent_dim
-        sigma2 = jnp.exp(2.0 * self.log_sigma)
+        sigma2 = self._sigma2()
         diff = x - self.loc
         # Small K x K capacitance matrix from the Woodbury identity.
         M = sigma2 * jnp.eye(k) + self.W.T @ self.W
@@ -89,7 +108,7 @@ class GaussianPCA(AbstractDistribution):
         #   quadratic = sigma^-2 * ||diff||^2 - sigma^-4 * (W^T diff)^T M^-1 (W^T diff).
         quad = jnp.sum(diff**2) / sigma2 - (Wt_diff @ y) / (sigma2**2)
         # Matrix determinant lemma:
-        #   log|Sigma| = 2(D-K) log sigma + log|M|.
+        #   log|Sigma| = (D-K) log(sigma^2) + log|M|.
         log_det_M = 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
-        log_det = 2.0 * (d - k) * self.log_sigma + log_det_M
+        log_det = (d - k) * jnp.log(sigma2) + log_det_M
         return -0.5 * (d * jnp.log(2.0 * jnp.pi) + log_det + quad)

--- a/tests/test_distributions_pca.py
+++ b/tests/test_distributions_pca.py
@@ -1,0 +1,79 @@
+"""Tests for the GaussianPCA (low-rank + diagonal Gaussian) base distribution."""
+
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy.stats as jstats
+import pytest
+
+from gauss_flows import GaussianPCA, gaussianization_flow
+
+
+def _reference_log_prob(dist: GaussianPCA, x):
+    return jstats.multivariate_normal.logpdf(x, dist.loc, dist.covariance())
+
+
+@pytest.mark.parametrize("latent_dim", [2, 5, 10])
+def test_log_prob_matches_full_covariance_reference(key, latent_dim):
+    k_init, k_x = jr.split(key)
+    dist = GaussianPCA(k_init, event_shape=(10,), latent_dim=latent_dim)
+    x = jr.normal(k_x, (10,))
+    actual = dist.log_prob(x)
+    expected = _reference_log_prob(dist, x)
+    assert jnp.allclose(actual, expected, atol=1e-5)
+
+
+def test_log_prob_batched(key):
+    dist = GaussianPCA(key, event_shape=(6,), latent_dim=3)
+    xs = jr.normal(jr.fold_in(key, 1), (32, 6))
+    lp = dist.log_prob(xs)
+    assert lp.shape == (32,)
+    expected = jnp.asarray([_reference_log_prob(dist, x) for x in xs])
+    assert jnp.allclose(lp, expected, atol=1e-5)
+
+
+def test_sample_shape_and_finite(key):
+    dist = GaussianPCA(key, event_shape=(5,), latent_dim=2)
+    samples = dist.sample(jr.fold_in(key, 1), sample_shape=(16,))
+    assert samples.shape == (16, 5)
+    assert jnp.all(jnp.isfinite(samples))
+
+
+def test_sample_moments_match_covariance(key):
+    """Empirical mean/cov from 20k samples match loc and W W^T + sigma^2 I."""
+    d, k = 5, 2
+    dist = GaussianPCA(key, event_shape=(d,), latent_dim=k, loc=0.0, W_init_scale=0.5)
+    samples = dist.sample(jr.fold_in(key, 1), sample_shape=(20_000,))
+    empirical_mean = samples.mean(axis=0)
+    centered = samples - empirical_mean
+    empirical_cov = centered.T @ centered / samples.shape[0]
+    assert jnp.allclose(empirical_mean, dist.loc, atol=0.05)
+    assert jnp.allclose(empirical_cov, dist.covariance(), atol=0.1)
+
+
+def test_as_base_dist_in_gaussianization_flow(key):
+    k_base, k_flow, k_sample = jr.split(key, 3)
+    base = GaussianPCA(k_base, event_shape=(4,), latent_dim=2)
+    flow = gaussianization_flow(k_flow, n_dims=4, n_layers=2, base_dist=base)
+    samples = flow.sample(k_sample, (8,))
+    log_probs = flow.log_prob(samples)
+    assert samples.shape == (8, 4)
+    assert log_probs.shape == (8,)
+    assert jnp.all(jnp.isfinite(log_probs))
+
+
+def test_latent_dim_bounds(key):
+    with pytest.raises(ValueError, match="latent_dim"):
+        GaussianPCA(key, event_shape=(3,), latent_dim=0)
+    with pytest.raises(ValueError, match="latent_dim"):
+        GaussianPCA(key, event_shape=(3,), latent_dim=4)
+
+
+def test_only_1d_event_shape(key):
+    with pytest.raises(ValueError, match="1D event"):
+        GaussianPCA(key, event_shape=(3, 2), latent_dim=1)
+
+
+def test_custom_loc(key):
+    loc = jnp.array([1.0, -2.0, 3.0])
+    dist = GaussianPCA(key, event_shape=(3,), latent_dim=2, loc=loc)
+    assert jnp.allclose(dist.loc, loc)

--- a/tests/test_distributions_pca.py
+++ b/tests/test_distributions_pca.py
@@ -77,3 +77,21 @@ def test_custom_loc(key):
     loc = jnp.array([1.0, -2.0, 3.0])
     dist = GaussianPCA(key, event_shape=(3,), latent_dim=2, loc=loc)
     assert jnp.allclose(dist.loc, loc)
+
+
+def test_log_prob_stable_for_very_negative_log_sigma(key):
+    """log_sigma deeply negative shouldn't make sigma^2 underflow to zero
+    and break Cholesky / Woodbury — the eps floor keeps log_prob finite.
+    """
+    import equinox as eqx
+
+    dist = GaussianPCA(key, event_shape=(4,), latent_dim=2)
+    dist = eqx.tree_at(lambda d: d.log_sigma, dist, jnp.asarray(-50.0))
+    x = jr.normal(jr.fold_in(key, 1), (4,))
+    lp = dist.log_prob(x)
+    assert jnp.isfinite(lp)
+
+
+def test_eps_must_be_non_negative(key):
+    with pytest.raises(ValueError, match="eps"):
+        GaussianPCA(key, event_shape=(3,), latent_dim=2, eps=-1.0)


### PR DESCRIPTION
## Summary

- New \`GaussianPCA\` base distribution under \`_src/distributions/pca.py\`: probabilistic-PCA-parametrised Gaussian with \`Sigma = W W^T + sigma^2 I\`, \`W in R^{D x K}\`. Parameters are \`W\`, \`log_sigma\`, \`loc\` (all trainable).
- **Woodbury-based log-prob**: the quadratic form uses the Woodbury identity via a small \`(K, K)\` capacitance matrix \`M = sigma^2 I_K + W^T W\`; the log-determinant uses the matrix-determinant lemma \`log|Sigma| = 2(D-K) log sigma + log|M|\`. Inversion stays \`O(K^3)\` (Cholesky on \`M\`) + \`O(DK)\`.
- Sampling is exact and reparametrised: \`x = loc + W z + sigma eps\`, \`z ~ N(0, I_K)\`, \`eps ~ N(0, I_D)\`.
- Exported from \`gauss_flows._src.distributions\` alongside \`GaussianMixture\`.

This PR is **stacked on #39** (GaussianMixture). Branch base is \`feat/gaussian-mixture-base\`; once that merges, retarget this PR to \`main\`.

Closes #22.

## Test plan

- [x] \`uv run pytest tests/test_distributions_pca.py -v\` — 10 new tests including log-prob parametrised over \`K in {2, 5, 10}\` against \`jstats.multivariate_normal.logpdf(x, loc, W W^T + sigma^2 I)\` at 1e-5; batched log-prob; sample shape; empirical mean/cov from 20k samples match \`loc\` / \`covariance()\` to tol 0.05/0.1; drop-in as \`base_dist\` in \`gaussianization_flow\`; bounds + shape validation; custom \`loc\`.
- [x] \`uv run pytest -q\` — full suite (75 tests) green.
- [x] \`uv run --group lint ruff check .\` + \`ruff format --check .\` — clean.
- [x] \`uv run --group typecheck ty check src/gauss_flows\` — clean.

The 50D EOF-recovery acceptance criterion from the issue is better framed as a fitting-demo notebook; it will land alongside #29 (base-dists tutorial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)