### PR TITLE
feat(pr-0): abstract surjection foundation + SurVAEFlow container

### DIFF
--- a/src/gauss_flows/__init__.py
+++ b/src/gauss_flows/__init__.py
@@ -8,6 +8,7 @@ from gauss_flows._src.distributions import (
     GaussianPCA,
 )
 from gauss_flows._src.flows import (
+    SurVAEFlow,
     coupling_gaussianization_flow,
     gaussianization_flow,
     iterative_rbig,
@@ -42,9 +43,15 @@ from gauss_flows._src.transforms import (
     Squeeze,
     SylvesterFlow,
 )
+from gauss_flows._src.transforms.base import (
+    AbstractStochastic,
+    AbstractSurjection,
+)
 
 
 __all__ = [
+    "AbstractStochastic",
+    "AbstractSurjection",
     "ActNorm",
     "ActNorm1D",
     "AffineCoupling",
@@ -66,6 +73,7 @@ __all__ = [
     "RQSplineCoupling",
     "RQSplineMarginal",
     "Squeeze",
+    "SurVAEFlow",
     "SylvesterFlow",
     "coupling_gaussianization_flow",
     "entropy",

--- a/src/gauss_flows/_src/_protocols.py
+++ b/src/gauss_flows/_src/_protocols.py
@@ -1,0 +1,33 @@
+"""Structural protocols used to plug external distribution objects into gauss_flows.
+
+These ``Protocol`` definitions describe the minimal duck-typed interfaces that
+SurVAE-style transforms (and their tests) need from a "conditional
+distribution" object — without forcing inheritance from any concrete base
+class. Concrete implementations can come from :mod:`numpyro.distributions`,
+:mod:`flowjax.distributions` (via thin wrappers), or user code.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from jax import Array
+from jaxtyping import PRNGKeyArray
+
+
+@runtime_checkable
+class ConditionalDistribution(Protocol):
+    """Minimal ``p(x | cond)`` interface.
+
+    Implementations must accept the conditioning variable as a keyword
+    argument (``condition=...``) — chosen so that the same call site works
+    whether the underlying distribution is conditional or unconditional
+    (in the latter case, the impl can simply ignore ``condition``).
+    """
+
+    def sample(self, key: PRNGKeyArray, *, condition: Array) -> Array: ...
+
+    def log_prob(self, value: Array, *, condition: Array) -> Array: ...
+
+
+__all__ = ["ConditionalDistribution"]

--- a/src/gauss_flows/_src/flows.py
+++ b/src/gauss_flows/_src/flows.py
@@ -186,33 +186,42 @@ def iterative_rbig(
     )
 
 
-def _forward_one(
+def _to_data(
     transform: AbstractBijection | AbstractSurjection,
     x: Array,
     key: PRNGKeyArray,
     cond: Array | None,
 ) -> tuple[Array, Array]:
-    """Apply one chain element in the forward (base -> data) direction.
+    """Apply one chain element in the base -> data direction (used by ``sample``).
 
-    Resolves the FlowJax-vs-SurVAE method-name and signature gap with a
-    single isinstance check so :class:`SurVAEFlow` keeps a uniform call
-    site without wrapping bijections in adapters.
+    Note the directional mismatch between the two ABCs: FlowJax's
+    ``AbstractBijection.transform_and_log_det`` is the base -> data
+    direction (its "sample" side), while SurVAE's
+    ``AbstractSurjection.inverse_and_log_det`` is the latent -> data
+    direction (latent ≡ base). The isinstance dispatch hides this so
+    :class:`SurVAEFlow` keeps a uniform call site without wrapping
+    bijections in adapters.
     """
     if isinstance(transform, AbstractBijection):
         return transform.transform_and_log_det(x, cond)
-    return transform.forward_and_log_det(x, key, cond)
+    return transform.inverse_and_log_det(x, key, cond)
 
 
-def _inverse_one(
+def _to_base(
     transform: AbstractBijection | AbstractSurjection,
     z: Array,
     key: PRNGKeyArray,
     cond: Array | None,
 ) -> tuple[Array, Array]:
-    """Apply one chain element in the inverse (data -> base) direction."""
+    """Apply one chain element in the data -> base direction (used by ``log_prob``).
+
+    Mirror of :func:`_to_data`: bijections use ``inverse_and_log_det``
+    (FlowJax's "log_prob" side), surjections use ``forward_and_log_det``
+    (SurVAE's data -> latent side).
+    """
     if isinstance(transform, AbstractBijection):
         return transform.inverse_and_log_det(z, cond)
-    return transform.inverse_and_log_det(z, key, cond)
+    return transform.forward_and_log_det(z, key, cond)
 
 
 class SurVAEFlow(eqx.Module):
@@ -265,13 +274,31 @@ class SurVAEFlow(eqx.Module):
         all_keys = jr.split(key, len(self.transforms) + 1)
         return all_keys[0], list(all_keys[1:])
 
+    def _single_sample(self, key: PRNGKeyArray, cond: Array | None) -> Array:
+        k_base, t_keys = self._split_keys(key)
+        x = self.base_dist._sample(k_base, cond)
+        for t, k_t in zip(self.transforms, t_keys, strict=True):
+            x, _ = _to_data(t, x, k_t, cond)
+        return x
+
+    def _single_log_prob(
+        self, x: Array, key: PRNGKeyArray, cond: Array | None
+    ) -> Array:
+        _k_base, t_keys = self._split_keys(key)
+        z = x
+        log_det = jnp.zeros(())
+        for t, k_t in zip(reversed(self.transforms), reversed(t_keys), strict=True):
+            z, ld = _to_base(t, z, k_t, cond)
+            log_det = log_det + ld
+        return self.base_dist._log_prob(z, cond) + log_det
+
     def sample(
         self,
         key: PRNGKeyArray,
         sample_shape: tuple[int, ...] = (),
         condition: ArrayLike | None = None,
     ) -> Array:
-        """Sample by drawing from ``base_dist`` and pushing forward.
+        """Sample by drawing from ``base_dist`` and pushing through to data.
 
         Each draw uses an independent key derived from ``key``; ``sample_shape``
         is realised via :func:`jax.vmap` over a leading batch of keys, mirroring
@@ -279,20 +306,13 @@ class SurVAEFlow(eqx.Module):
         """
         cond = None if condition is None else jnp.asarray(condition)
 
-        def _single(k: PRNGKeyArray) -> Array:
-            k_base, t_keys = self._split_keys(k)
-            x = self.base_dist._sample(k_base, cond)
-            for t, k_t in zip(self.transforms, t_keys, strict=True):
-                x, _ = _forward_one(t, x, k_t, cond)
-            return x
-
         if sample_shape == ():
-            return _single(key)
+            return self._single_sample(key, cond)
         n = 1
         for s in sample_shape:
             n *= s
         keys = jr.split(key, n)
-        flat = jax.vmap(_single)(keys)
+        flat = jax.vmap(lambda k: self._single_sample(k, cond))(keys)
         return flat.reshape(sample_shape + flat.shape[1:])
 
     def log_prob(
@@ -303,17 +323,34 @@ class SurVAEFlow(eqx.Module):
     ) -> Array:
         """Evaluate ``log p(x)`` (or its lower bound if any surjection is lower-bound).
 
-        For deterministic chains (bijections + non-stochastic surjections),
-        ``key`` is unused and any value can be passed.
+        Accepts batched inputs of shape ``sample_shape + base_dist.shape``;
+        the leading ``sample_shape`` dimensions are vmapped over and each
+        sample receives its own key derived from ``key``. For deterministic
+        chains (bijections + non-stochastic surjections) the key is unused
+        but still consumed by the dispatch.
         """
         cond = None if condition is None else jnp.asarray(condition)
-        _k_base, t_keys = self._split_keys(key)
-        z = jnp.asarray(x)
-        log_det = jnp.zeros(())
-        for t, k_t in zip(reversed(self.transforms), reversed(t_keys), strict=True):
-            z, ld = _inverse_one(t, z, k_t, cond)
-            log_det = log_det + ld
-        return self.base_dist._log_prob(z, cond) + log_det
+        x = jnp.asarray(x)
+
+        event_shape = self.base_dist.shape
+        n_event = len(event_shape)
+        if n_event > 0 and x.shape[-n_event:] != event_shape:
+            raise ValueError(
+                f"x trailing shape {x.shape[-n_event:]} does not match "
+                f"base_dist.shape {event_shape}."
+            )
+        sample_shape = x.shape if n_event == 0 else x.shape[:-n_event]
+
+        if sample_shape == ():
+            return self._single_log_prob(x, key, cond)
+
+        n = 1
+        for s in sample_shape:
+            n *= s
+        flat = x.reshape((n, *event_shape))
+        keys = jr.split(key, n)
+        out = jax.vmap(lambda xi, ki: self._single_log_prob(xi, ki, cond))(flat, keys)
+        return out.reshape(sample_shape)
 
 
 __all__ = [

--- a/src/gauss_flows/_src/flows.py
+++ b/src/gauss_flows/_src/flows.py
@@ -2,16 +2,21 @@
 
 This module provides factory functions for constructing various normalizing
 flow architectures based on RBIG (Rotation-Based Iterative Gaussianization)
-and related methods.
+and related methods, plus the :class:`SurVAEFlow` container that mixes
+ordinary FlowJax bijections with the keyed surjection / stochastic
+transforms defined in :mod:`gauss_flows._src.transforms.base`.
 """
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.random as jr
-from flowjax.bijections import Chain, Flip, Invert, Permute, Scan
+from flowjax.bijections import AbstractBijection, Chain, Flip, Invert, Permute, Scan
 from flowjax.distributions import AbstractDistribution, Normal, Transformed
-from jaxtyping import PRNGKeyArray
+from jax import Array
+from jaxtyping import ArrayLike, PRNGKeyArray
 
+from gauss_flows._src.transforms.base import AbstractSurjection
 from gauss_flows._src.transforms.coupling import RQSplineCoupling
 from gauss_flows._src.transforms.marginal import MixtureGaussianCDF
 from gauss_flows._src.transforms.rotation import (
@@ -181,7 +186,138 @@ def iterative_rbig(
     )
 
 
+def _forward_one(
+    transform: AbstractBijection | AbstractSurjection,
+    x: Array,
+    key: PRNGKeyArray,
+    cond: Array | None,
+) -> tuple[Array, Array]:
+    """Apply one chain element in the forward (base -> data) direction.
+
+    Resolves the FlowJax-vs-SurVAE method-name and signature gap with a
+    single isinstance check so :class:`SurVAEFlow` keeps a uniform call
+    site without wrapping bijections in adapters.
+    """
+    if isinstance(transform, AbstractBijection):
+        return transform.transform_and_log_det(x, cond)
+    return transform.forward_and_log_det(x, key, cond)
+
+
+def _inverse_one(
+    transform: AbstractBijection | AbstractSurjection,
+    z: Array,
+    key: PRNGKeyArray,
+    cond: Array | None,
+) -> tuple[Array, Array]:
+    """Apply one chain element in the inverse (data -> base) direction."""
+    if isinstance(transform, AbstractBijection):
+        return transform.inverse_and_log_det(z, cond)
+    return transform.inverse_and_log_det(z, key, cond)
+
+
+class SurVAEFlow(eqx.Module):
+    """Container that threads PRNG keys through a mixed bijection / surjection chain.
+
+    Composes any sequence of :class:`flowjax.bijections.AbstractBijection` and
+    :class:`AbstractSurjection` transforms. Forward direction is base -> data
+    (used by ``sample``); inverse direction is data -> base (used by
+    ``log_prob``). Each transform receives its own independent split of the
+    user-supplied key, regardless of whether it actually consumes it — this
+    keeps the call shape uniform and JIT-friendly.
+
+    For a chain consisting solely of :class:`AbstractBijection` instances,
+    ``log_prob`` is identical (up to numerical noise) to that of the
+    equivalent ``flowjax.distributions.Transformed(base, Chain(transforms))``,
+    so users can migrate without changing semantics.
+
+    Attributes:
+        base_dist: A :class:`flowjax.distributions.AbstractDistribution`
+            whose event shape matches the start of the forward chain.
+        transforms: Tuple of bijections / surjections, applied left-to-right
+            in the forward direction.
+
+    Properties:
+        lower_bound: ``True`` iff at least one surjection in the chain
+            contributes a lower bound to ``log_prob`` (i.e. has its
+            class-level ``lower_bound`` flag set).
+    """
+
+    base_dist: AbstractDistribution
+    transforms: tuple[AbstractBijection | AbstractSurjection, ...]
+
+    def __init__(
+        self,
+        base_dist: AbstractDistribution,
+        transforms: tuple[AbstractBijection | AbstractSurjection, ...]
+        | list[AbstractBijection | AbstractSurjection],
+    ):
+        self.base_dist = base_dist
+        self.transforms = tuple(transforms)
+
+    @property
+    def lower_bound(self) -> bool:
+        return any(
+            isinstance(t, AbstractSurjection) and t.lower_bound for t in self.transforms
+        )
+
+    def _split_keys(self, key: PRNGKeyArray) -> tuple[PRNGKeyArray, list[PRNGKeyArray]]:
+        """Split ``key`` into one base-distribution key plus one per transform."""
+        all_keys = jr.split(key, len(self.transforms) + 1)
+        return all_keys[0], list(all_keys[1:])
+
+    def sample(
+        self,
+        key: PRNGKeyArray,
+        sample_shape: tuple[int, ...] = (),
+        condition: ArrayLike | None = None,
+    ) -> Array:
+        """Sample by drawing from ``base_dist`` and pushing forward.
+
+        Each draw uses an independent key derived from ``key``; ``sample_shape``
+        is realised via :func:`jax.vmap` over a leading batch of keys, mirroring
+        the FlowJax convention.
+        """
+        cond = None if condition is None else jnp.asarray(condition)
+
+        def _single(k: PRNGKeyArray) -> Array:
+            k_base, t_keys = self._split_keys(k)
+            x = self.base_dist._sample(k_base, cond)
+            for t, k_t in zip(self.transforms, t_keys, strict=True):
+                x, _ = _forward_one(t, x, k_t, cond)
+            return x
+
+        if sample_shape == ():
+            return _single(key)
+        n = 1
+        for s in sample_shape:
+            n *= s
+        keys = jr.split(key, n)
+        flat = jax.vmap(_single)(keys)
+        return flat.reshape(sample_shape + flat.shape[1:])
+
+    def log_prob(
+        self,
+        x: ArrayLike,
+        key: PRNGKeyArray,
+        condition: ArrayLike | None = None,
+    ) -> Array:
+        """Evaluate ``log p(x)`` (or its lower bound if any surjection is lower-bound).
+
+        For deterministic chains (bijections + non-stochastic surjections),
+        ``key`` is unused and any value can be passed.
+        """
+        cond = None if condition is None else jnp.asarray(condition)
+        _k_base, t_keys = self._split_keys(key)
+        z = jnp.asarray(x)
+        log_det = jnp.zeros(())
+        for t, k_t in zip(reversed(self.transforms), reversed(t_keys), strict=True):
+            z, ld = _inverse_one(t, z, k_t, cond)
+            log_det = log_det + ld
+        return self.base_dist._log_prob(z, cond) + log_det
+
+
 __all__ = [
+    "SurVAEFlow",
     "coupling_gaussianization_flow",
     "gaussianization_flow",
     "iterative_rbig",

--- a/src/gauss_flows/_src/transforms/base.py
+++ b/src/gauss_flows/_src/transforms/base.py
@@ -1,0 +1,133 @@
+"""Foundation types for SurVAE-style flows: surjections and stochastic transforms.
+
+Surjections (Nielsen et al. 2020) are deterministic in one direction and
+stochastic in the other. Stochastic transforms (e.g. VAE encoders/decoders)
+are stochastic in both directions. Together with ordinary FlowJax
+bijections they form the SurVAE hierarchy:
+
+    Transform (base)
+    |- Bijection            <- flowjax.bijections.AbstractBijection
+    |- Surjection           <- AbstractSurjection (this module)
+    |   |- Inference        deterministic forward, stochastic inverse
+    |   `- Generative       stochastic forward, deterministic inverse
+    `- Stochastic           <- AbstractStochastic (both directions stochastic)
+
+This is a *parallel* hierarchy: surjections do **not** inherit from
+``flowjax.bijections.AbstractBijection``. They implement keyed
+``forward_and_log_det(x, key, cond=None)`` /
+``inverse_and_log_det(z, key, cond=None)`` methods so that PRNG keys can be
+threaded through the chain. ``SurVAEFlow`` is the container that mixes
+bijections with surjections.
+
+References:
+    Nielsen, Jaini, Hoogeboom, Winther, Welling.
+    *SurVAE Flows: Surjections to Bridge the Gap between VAEs and Flows.*
+    NeurIPS 2020.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import ClassVar
+
+import equinox as eqx
+import jax.numpy as jnp
+from jax import Array
+from jaxtyping import ArrayLike, PRNGKeyArray
+
+
+class AbstractSurjection(eqx.Module):
+    """Base class for SurVAE surjective transforms.
+
+    Subclasses set the three class-level flags so :class:`SurVAEFlow` (and
+    other containers) can decide whether ``log_prob`` is exact or only an
+    evidence lower bound:
+
+    Attributes:
+        stochastic_forward: ``True`` iff ``forward_and_log_det`` consumes
+            ``key`` and the result is a sample from a non-degenerate
+            distribution. ``False`` for deterministic forward (e.g.
+            inference surjections like ``Slice``).
+        stochastic_inverse: ``True`` iff ``inverse_and_log_det`` consumes
+            ``key`` and is a sample from a non-degenerate distribution.
+            ``False`` for deterministic inverse (e.g. generative
+            surjections like ``Augment``).
+        lower_bound: ``True`` iff the surjection's contribution to
+            ``log_prob`` is a lower bound rather than the exact value.
+            For Nielsen-style surjections this is equivalent to
+            ``stochastic_forward`` (the forward direction is the one used
+            inside ``log_prob``).
+    """
+
+    stochastic_forward: ClassVar[bool]
+    stochastic_inverse: ClassVar[bool]
+    lower_bound: ClassVar[bool]
+
+    @abstractmethod
+    def forward_and_log_det(
+        self,
+        x: ArrayLike,
+        key: PRNGKeyArray,
+        cond: Array | None = None,
+    ) -> tuple[Array, Array]:
+        """Compute ``z = f(x)`` and ``log |det J_f(x)|`` (or its bound)."""
+
+    @abstractmethod
+    def inverse_and_log_det(
+        self,
+        z: ArrayLike,
+        key: PRNGKeyArray,
+        cond: Array | None = None,
+    ) -> tuple[Array, Array]:
+        """Compute ``x = f^{-1}(z)`` and ``log |det J_{f^{-1}}(z)|`` (or its bound)."""
+
+
+class AbstractStochastic(AbstractSurjection):
+    """Base class for transforms that are stochastic in **both** directions.
+
+    Canonical example: a VAE layer where ``forward`` samples from
+    ``q(z | x)`` and ``inverse`` samples from ``p(x | z)``. ``log_prob``
+    returns an ELBO contribution.
+    """
+
+    stochastic_forward: ClassVar[bool] = True
+    stochastic_inverse: ClassVar[bool] = True
+    lower_bound: ClassVar[bool] = True
+
+
+class _IdentitySurjection(AbstractSurjection):
+    """Concrete identity surjection used as a smoke test for the ABC.
+
+    Both directions are deterministic and the log-determinant is zero —
+    behaves exactly like a unit-Jacobian bijection but exposes the
+    keyed surjection signature.
+    """
+
+    stochastic_forward: ClassVar[bool] = False
+    stochastic_inverse: ClassVar[bool] = False
+    lower_bound: ClassVar[bool] = False
+
+    def forward_and_log_det(
+        self,
+        x: ArrayLike,
+        key: PRNGKeyArray,
+        cond: Array | None = None,
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(x), jnp.zeros(())
+
+    def inverse_and_log_det(
+        self,
+        z: ArrayLike,
+        key: PRNGKeyArray,
+        cond: Array | None = None,
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(z), jnp.zeros(())
+
+
+__all__ = [
+    "AbstractStochastic",
+    "AbstractSurjection",
+    "_IdentitySurjection",
+]

--- a/tests/test_survae_base.py
+++ b/tests/test_survae_base.py
@@ -159,10 +159,9 @@ def test_log_prob_matches_flowjax_transformed_for_bijection_only_chain(key):
     reference = Transformed(base, Chain(bijections))
 
     xs = jr.normal(jr.fold_in(key, 10), (8, 3))
-    actual = jnp.asarray(
-        [survae.log_prob(x, jr.fold_in(key, i)) for i, x in enumerate(xs)]
-    )
+    actual = survae.log_prob(xs, jr.fold_in(key, 11))
     expected = reference.log_prob(xs)
+    assert actual.shape == (8,)
     assert jnp.allclose(actual, expected, atol=1e-5)
 
 
@@ -175,13 +174,79 @@ def test_sample_shape_for_bijection_only_chain(key):
     assert batched.shape == (7, 3)
 
 
+class _ShiftSurjection(AbstractSurjection):
+    """Asymmetric shift surjection used to detect direction-dispatch bugs.
+
+    ``forward`` (data -> latent) subtracts ``shift``; ``inverse``
+    (latent -> data) adds it. If :class:`SurVAEFlow.sample` accidentally
+    called ``forward_and_log_det`` (or ``log_prob`` called ``inverse``)
+    the round-trip would break by ``2 * shift``.
+    """
+
+    stochastic_forward: ClassVar[bool] = False
+    stochastic_inverse: ClassVar[bool] = False
+    lower_bound: ClassVar[bool] = False
+    shift: Array
+
+    def __init__(self, shift: Array):
+        self.shift = shift
+
+    def forward_and_log_det(
+        self, x: ArrayLike, key: PRNGKeyArray, cond: Array | None = None
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(x) - self.shift, jnp.zeros(())
+
+    def inverse_and_log_det(
+        self, z: ArrayLike, key: PRNGKeyArray, cond: Array | None = None
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(z) + self.shift, jnp.zeros(())
+
+
+def test_sample_uses_surjection_inverse_direction(key):
+    """Regression: SurVAEFlow.sample must apply surjection.inverse (latent -> data)."""
+    base = Normal(jnp.zeros(3))
+    shift = jnp.array([1.0, -2.0, 0.5])
+    flow = SurVAEFlow(base, [_ShiftSurjection(shift)])
+    # SurVAEFlow splits the user key into one base subkey + one per transform,
+    # so to predict the sample we draw the base from that same subkey.
+    user_key = jr.fold_in(key, 1)
+    base_key, _ = flow._split_keys(user_key)
+    z = base._sample(base_key)
+    sample = flow._single_sample(user_key, None)
+    assert jnp.allclose(sample, z + shift, atol=1e-6)
+
+
+def test_log_prob_uses_surjection_forward_direction(key):
+    """SurVAEFlow.log_prob must apply surjection.forward (data -> latent)."""
+    base = Normal(jnp.zeros(3))
+    shift = jnp.array([1.0, -2.0, 0.5])
+    flow = SurVAEFlow(base, [_ShiftSurjection(shift)])
+    x = jr.normal(jr.fold_in(key, 1), (3,))
+    # log_prob should evaluate base.log_prob at (x - shift).
+    actual = flow.log_prob(x, jr.fold_in(key, 2))
+    expected = base.log_prob(x - shift)
+    assert jnp.allclose(actual, expected, atol=1e-6)
+
+
+def test_sample_log_prob_round_trip_with_asymmetric_surjection(key):
+    """End-to-end: log_prob of a fresh sample equals base.log_prob of the base draw."""
+    base = Normal(jnp.zeros(3))
+    shift = jnp.array([1.0, -2.0, 0.5])
+    flow = SurVAEFlow(base, [_ShiftSurjection(shift)])
+    samples = flow.sample(jr.fold_in(key, 1), sample_shape=(16,))
+    log_probs = flow.log_prob(samples, jr.fold_in(key, 2))
+    # samples = base_draws + shift, so log_prob(samples) = base.log_prob(base_draws).
+    expected = base.log_prob(samples - shift)
+    assert jnp.allclose(log_probs, expected, atol=1e-5)
+
+
 def test_sample_log_prob_finite_with_identity_surjection(key):
     base = Normal(jnp.zeros(3))
     flow = SurVAEFlow(base, [Affine(loc=jnp.zeros(3)), _IdentitySurjection()])
     samples = flow.sample(jr.fold_in(key, 1), sample_shape=(8,))
-    log_probs = jnp.asarray(
-        [flow.log_prob(x, jr.fold_in(key, i)) for i, x in enumerate(samples)]
-    )
+    log_probs = flow.log_prob(samples, jr.fold_in(key, 2))
     assert samples.shape == (8, 3)
     assert log_probs.shape == (8,)
     assert jnp.all(jnp.isfinite(log_probs))

--- a/tests/test_survae_base.py
+++ b/tests/test_survae_base.py
@@ -1,0 +1,210 @@
+"""Tests for the SurVAE foundation: AbstractSurjection + SurVAEFlow."""
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from flowjax.bijections import Affine, Chain
+from flowjax.distributions import Normal, Transformed
+from jax import Array
+from jaxtyping import ArrayLike, PRNGKeyArray
+
+from gauss_flows import (
+    AbstractStochastic,
+    AbstractSurjection,
+    SurVAEFlow,
+)
+from gauss_flows._src._protocols import ConditionalDistribution
+from gauss_flows._src.transforms.base import _IdentitySurjection
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: minimal concrete surjections for each lower_bound category.
+# ---------------------------------------------------------------------------
+
+
+class _DeterministicSurjection(AbstractSurjection):
+    """Inference-style surjection: exact log_prob (no lower bound)."""
+
+    stochastic_forward: ClassVar[bool] = False
+    stochastic_inverse: ClassVar[bool] = False
+    lower_bound: ClassVar[bool] = False
+
+    def forward_and_log_det(
+        self, x: ArrayLike, key: PRNGKeyArray, cond: Array | None = None
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(x), jnp.zeros(())
+
+    def inverse_and_log_det(
+        self, z: ArrayLike, key: PRNGKeyArray, cond: Array | None = None
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(z), jnp.zeros(())
+
+
+class _LowerBoundSurjection(AbstractSurjection):
+    """Generative-style surjection: contributes a lower bound."""
+
+    stochastic_forward: ClassVar[bool] = True
+    stochastic_inverse: ClassVar[bool] = False
+    lower_bound: ClassVar[bool] = True
+
+    def forward_and_log_det(
+        self, x: ArrayLike, key: PRNGKeyArray, cond: Array | None = None
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(x), jnp.zeros(())
+
+    def inverse_and_log_det(
+        self, z: ArrayLike, key: PRNGKeyArray, cond: Array | None = None
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(z), jnp.zeros(())
+
+
+class _IdentityStochastic(AbstractStochastic):
+    """Stochastic-both-ways: contributes a lower bound (inherited)."""
+
+    def forward_and_log_det(
+        self, x: ArrayLike, key: PRNGKeyArray, cond: Array | None = None
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(x), jnp.zeros(())
+
+    def inverse_and_log_det(
+        self, z: ArrayLike, key: PRNGKeyArray, cond: Array | None = None
+    ) -> tuple[Array, Array]:
+        del key, cond
+        return jnp.asarray(z), jnp.zeros(())
+
+
+# ---------------------------------------------------------------------------
+# AbstractSurjection ABC behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_abstract_surjection_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        AbstractSurjection()  # type: ignore[abstract]
+
+
+def test_identity_surjection_is_concrete(key):
+    surj = _IdentitySurjection()
+    x = jr.normal(key, (3,))
+    z, ld_f = surj.forward_and_log_det(x, key)
+    x_back, ld_i = surj.inverse_and_log_det(z, key)
+    assert jnp.allclose(z, x)
+    assert jnp.allclose(x_back, x)
+    assert ld_f == 0.0
+    assert ld_i == 0.0
+
+
+def test_abstract_stochastic_inherits_flags():
+    assert AbstractStochastic.stochastic_forward is True
+    assert AbstractStochastic.stochastic_inverse is True
+    assert AbstractStochastic.lower_bound is True
+
+
+# ---------------------------------------------------------------------------
+# SurVAEFlow.lower_bound flag derivation
+# ---------------------------------------------------------------------------
+
+
+def test_lower_bound_bijection_only(key):
+    base = Normal(jnp.zeros(2))
+    flow = SurVAEFlow(base, [Affine(loc=jnp.zeros(2))])
+    assert flow.lower_bound is False
+
+
+def test_lower_bound_with_inference_surjection(key):
+    base = Normal(jnp.zeros(2))
+    flow = SurVAEFlow(base, [Affine(loc=jnp.zeros(2)), _DeterministicSurjection()])
+    assert flow.lower_bound is False
+
+
+def test_lower_bound_with_generative_surjection(key):
+    base = Normal(jnp.zeros(2))
+    flow = SurVAEFlow(base, [Affine(loc=jnp.zeros(2)), _LowerBoundSurjection()])
+    assert flow.lower_bound is True
+
+
+def test_lower_bound_with_stochastic_transform(key):
+    base = Normal(jnp.zeros(2))
+    flow = SurVAEFlow(base, [Affine(loc=jnp.zeros(2)), _IdentityStochastic()])
+    assert flow.lower_bound is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: bijection-only SurVAEFlow matches flowjax.Transformed
+# ---------------------------------------------------------------------------
+
+
+def _make_bijection_chain(key):
+    k1, k2 = jr.split(key)
+    return [
+        Affine(loc=jr.normal(k1, (3,)), scale=jnp.exp(jr.normal(k2, (3,)) * 0.3)),
+        Affine(
+            loc=jr.normal(jr.fold_in(key, 1), (3,)),
+            scale=jnp.exp(jr.normal(jr.fold_in(key, 2), (3,)) * 0.3),
+        ),
+    ]
+
+
+def test_log_prob_matches_flowjax_transformed_for_bijection_only_chain(key):
+    base = Normal(jnp.zeros(3))
+    bijections = _make_bijection_chain(key)
+    survae = SurVAEFlow(base, bijections)
+    reference = Transformed(base, Chain(bijections))
+
+    xs = jr.normal(jr.fold_in(key, 10), (8, 3))
+    actual = jnp.asarray(
+        [survae.log_prob(x, jr.fold_in(key, i)) for i, x in enumerate(xs)]
+    )
+    expected = reference.log_prob(xs)
+    assert jnp.allclose(actual, expected, atol=1e-5)
+
+
+def test_sample_shape_for_bijection_only_chain(key):
+    base = Normal(jnp.zeros(3))
+    flow = SurVAEFlow(base, _make_bijection_chain(key))
+    single = flow.sample(jr.fold_in(key, 1))
+    assert single.shape == (3,)
+    batched = flow.sample(jr.fold_in(key, 2), sample_shape=(7,))
+    assert batched.shape == (7, 3)
+
+
+def test_sample_log_prob_finite_with_identity_surjection(key):
+    base = Normal(jnp.zeros(3))
+    flow = SurVAEFlow(base, [Affine(loc=jnp.zeros(3)), _IdentitySurjection()])
+    samples = flow.sample(jr.fold_in(key, 1), sample_shape=(8,))
+    log_probs = jnp.asarray(
+        [flow.log_prob(x, jr.fold_in(key, i)) for i, x in enumerate(samples)]
+    )
+    assert samples.shape == (8, 3)
+    assert log_probs.shape == (8,)
+    assert jnp.all(jnp.isfinite(log_probs))
+
+
+# ---------------------------------------------------------------------------
+# ConditionalDistribution structural protocol
+# ---------------------------------------------------------------------------
+
+
+def test_conditional_distribution_protocol_runtime_checkable():
+    class _Stub:
+        def sample(self, key, *, condition):
+            return condition
+
+        def log_prob(self, value, *, condition):
+            return jnp.zeros(())
+
+    assert isinstance(_Stub(), ConditionalDistribution)
+    # A bare object lacking the required methods should fail the check.
+
+    class _Missing:
+        def sample(self, key, *, condition):
+            return condition
+
+    assert not isinstance(_Missing(), ConditionalDistribution)


### PR DESCRIPTION
## Summary

Foundational PR for the SurVAE extension (Phase 2 critical path). Sets up the parallel type hierarchy that surjections and stochastic transforms plug into, plus the container that mixes them with FlowJax bijections.

- **\`src/gauss_flows/_src/transforms/base.py\`** — \`AbstractSurjection(eqx.Module)\` with \`ClassVar\` flags (\`stochastic_forward\`, \`stochastic_inverse\`, \`lower_bound\`) and abstract keyed \`forward_and_log_det(x, key, cond)\` / \`inverse_and_log_det(z, key, cond)\` methods. \`AbstractStochastic\` subclass for VAE-style transforms (defaults \`True/True/True\`). \`_IdentitySurjection\` for ABC smoke tests.
- **\`src/gauss_flows/_src/_protocols.py\`** — runtime-checkable \`ConditionalDistribution\` Protocol with \`sample(key, *, condition)\` and \`log_prob(value, *, condition)\` so external distribution objects (numpyro, flowjax wrappers, custom) can be plugged in without inheritance.
- **\`src/gauss_flows/_src/flows.py\`** — new \`SurVAEFlow(eqx.Module)\` container. \`sample\` and \`log_prob\` thread keys through the chain via isinstance dispatch on \`AbstractBijection\` vs \`AbstractSurjection\` (**Option A** chosen over an adapter wrapper, so \`flow.transforms[0]\` stays as the original bijection for debugging / introspection). \`lower_bound\` is OR'd over the per-class \`lower_bound\` flags of any surjection in the chain.

**Zero regression for bijection-only users** — the existing \`gaussianization_flow\` / \`coupling_gaussianization_flow\` / \`Transformed\` paths are untouched.

Closes #7.

## Test plan

- [x] \`uv run pytest tests/test_survae_base.py -v\` — 11 new tests:
  - ABC: cannot instantiate \`AbstractSurjection\`; \`_IdentitySurjection\` works; \`AbstractStochastic\` flag inheritance.
  - \`lower_bound\` derivation across all four chain compositions (bijection-only / + inference surjection / + generative surjection / + stochastic).
  - Regression: bijection-only \`SurVAEFlow.log_prob\` matches \`flowjax.Transformed.log_prob\` to 1e-5 over a batch.
  - \`sample\` shapes for single + batched draws.
  - End-to-end sample + log_prob with \`_IdentitySurjection\` in the chain stays finite.
  - \`ConditionalDistribution\` Protocol passes/fails \`isinstance\` correctly.
- [x] \`uv run pytest -q\` — full suite (108 tests) green.
- [x] \`uv run --group lint ruff check .\` + \`ruff format --check .\` — clean.
- [x] \`uv run --group typecheck ty check src/gauss_flows\` — clean.

## What this unblocks

PR-1 (#8) simple surjections, PR-2 (#9) Slice + Augment, PR-6 (#13) DeepSigmoid + HistogramCDF can all now plug into the \`AbstractSurjection\` interface and be composed via \`SurVAEFlow\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)