### PR TITLE
chore: import scaffolding from pypackage_template

### DIFF
--- a/.claude/commands/create-gh-issue.md
+++ b/.claude/commands/create-gh-issue.md
@@ -1,0 +1,189 @@
+Open GitHub issues using this project's issue templates, with correct labels, milestone, and relationships applied.
+
+Use this skill when the user asks to file an issue, open an issue, create a feature / design / bug / research / epic, or when publishing draft issues from a wave-backlog file into real GitHub issues. It pairs with `link-gh-issues` for applying native sub-issue and blocked-by links after creation.
+
+## When to invoke
+
+- "Open an issue for X" / "file an issue about Y"
+- "Create a feature issue for the new `blr_full_rank` wrapper"
+- "Open an epic for Wave 2"
+- "Publish the drafts in `.plans/wave-1-backlog.md` as real issues"
+- "Convert this research note into a research issue"
+
+## Templates available
+
+Issue templates live in `.github/ISSUE_TEMPLATE/`. Pick the one that matches the work:
+
+| Template | Use when |
+|---|---|
+| `epic-wave.md` | Opening a release-scoped wave (owns a milestone; groups several Theme epics) |
+| `epic-theme.md` | Grouping related feature / design / chore issues within a wave |
+| `feature.md` | One substantial deliverable (new API, module, notebook, etc.) |
+| `design.md` | Resolving an open design question — ADR-style |
+| `bug.md` | Something isn't working |
+| `research.md` | Comparative analysis / prior-art survey → prioritized roadmap of follow-up issues |
+
+If unsure, ask the user before proceeding. Default for ambiguous "add X" requests is `feature.md`.
+
+## Decision tree for picking a template
+
+```
+Does the user want to resolve an open API / architectural question?      → design.md
+Is the user describing broken behaviour + reproduction?                   → bug.md
+Is the user asking for a survey of external repos / papers / prior art?  → research.md
+Is the user planning a release or multi-issue phase?                      → epic-wave.md
+Is the user grouping related issues under a wave?                         → epic-theme.md
+Otherwise (substantial single deliverable)                                → feature.md
+```
+
+## Step-by-step workflow
+
+### Step 1 — Confirm scope with the user
+
+Before opening any issue, confirm these five inputs with the user (or infer from context and echo back):
+
+1. **Template** — which of the six (see table above)
+2. **Title** — follow the template's title convention:
+   - Feature / chore: `<scope>: <short description>` — e.g. `feat(primitives): diagonal BLR update step`
+   - Design: `[Design] <question>` — e.g. `[Design] per-parameter prior: pytree vs scalar`
+   - Research: `research: <topic>` — e.g. `research: parallel-in-time filters vs this project`
+   - Bug: `bug: <short description>`
+   - Epic wave: `[EPIC] Wave N: <title>`
+   - Epic theme: `[EPIC] <theme title>`
+3. **Parent theme/wave epic** (if any) — the issue number this child rolls up to
+4. **Wave / milestone** — which `wave:*` label + which `vX.Y-<slug>` milestone
+5. **Additional labels** — which `area:*`, `layer:*`, `priority:*` apply (see Step 4)
+
+### Step 2 — Draft the body
+
+Read the template file at `.github/ISSUE_TEMPLATE/<template>.md` and use it as the scaffold. Strip:
+
+- The YAML frontmatter (`---` block at the top)
+- HTML comments that are pure guidance (e.g. `<!-- Delete if not needed. -->`) — keep comments that describe what the section contains if the filled-in body would benefit from the note
+
+Fill in sections according to the template's intent. **Minimum required sections** (never leave empty):
+
+| Template | Required |
+|---|---|
+| `feature.md` | Problem / Request, User Story, Motivation, Proposed API, Implementation Steps, Definition of Done, Testing, Relationships |
+| `design.md` | Problem / Question, Proposed Options, Alternatives Considered, Relationships |
+| `bug.md` | Problem, Reproduction, Expected Behavior, Actual Behavior, Environment, Relationships |
+| `research.md` | Title, Context, §1 What the subject contains, §2 Comparison, §3 Summary Table, §5 Proposed Follow-up Issues, Relationships |
+| `epic-wave.md` | Goal, Motivation, Theme Epics, Definition of Done (Wave), Relationships |
+| `epic-theme.md` | Theme, Parent Wave, Issues, Definition of Done, Relationships |
+
+**Optional / renameable sections** on `feature.md` and `design.md`:
+
+- `## Design Snapshot` — rename to fit the content (e.g. `## Demo To Implement`, `## Demo Snippet To Include`, `## Config Snippet`, `## Reference Trace`, `## Prior Art Snippets`). Lead with the exact code / config the implementer will reproduce. Delete the section if not relevant.
+- `## Mathematical Notes` — rename if warranted (`## Numerical Notes`, `## Stability Notes`, `## Equations To Test`). Delete if not relevant.
+
+### Step 3 — Apply the style conventions
+
+- **Unicode math in prose** — prefer `σ²`, `E₁`, `∑`, `⊗`, `≈`, `Λ⁻¹`, `∂/∂x`, `O(d³)` over LaTeX / MathJax blocks. Keeps the issue readable in the GH UI and plain-text tools.
+- **`text`-tagged code fences for multi-line equations** so pseudo-math isn't syntax-highlighted as Python. Wrap the example in a 4-backtick outer fence so the nested triple-backtick block renders intact:
+
+  ````
+  ```text
+  s_next   = (1 - ρ) · s   + ρ · (s₀   - h)
+  η_next   = (1 - ρ) · η   + ρ · (η₀ + g - h ⊙ m)
+  ```
+  ````
+
+- **Code-first, prose-last** — Design Snapshot and Proposed API should LEAD with the exact snippet the implementer will reproduce; prose goes after.
+- **Concrete implementation steps** — each step should name the file path + function, not a generic `...`. Example: `Add \`blr_diag_update_step\` in \`src/optax_bayes/_src/primitives.py\``
+
+### Step 4 — Pick labels
+
+Every issue carries exactly one `type:*`, one or more `area:*`, at most one `layer:*`, one `wave:*`, and one `priority:*`. Common combinations:
+
+| Work type | Labels |
+|---|---|
+| L0 primitive implementation | `type:feature`, `area:algorithmic`, `layer:0-primitives`, `wave:N-…`, `priority:p1` |
+| L1 component implementation | `type:feature`, `area:algorithmic`, `layer:1-components`, `wave:N-…` |
+| L2 wrapper / public API | `type:feature`, `area:algorithmic`, `layer:2-models`, `wave:N-…` |
+| Test coverage | `type:feature`, `area:testing`, `wave:N-…` |
+| Notebook / docs page | `type:docs`, `area:docs`, `wave:N-…` |
+| Design / ADR | `type:design`, `area:algorithmic` (or `area:engineering`), `wave:N-…` |
+| Research / survey | `type:research`, `area:algorithmic` (or relevant area) |
+| Engineering / CI / packaging | `type:chore`, `area:engineering`, `wave:0-bootstrap` |
+
+Wave labels and milestones are project-specific — check `docs/contributing.md` or `boundaries.md` for the current roadmap before picking.
+
+### Step 5 — Create the issue
+
+**CLI path (preferred for drafted bodies):**
+
+Write the drafted body to a temporary file, then:
+
+```bash
+gh issue create \
+  --title "feat(primitives): diagonal BLR update step" \
+  --body-file /tmp/issue-body.md \
+  --label "type:feature,area:algorithmic,layer:0-primitives,wave:1-diagonal,priority:p1" \
+  --milestone "v0.1-diagonal"
+```
+
+Returns the new issue's URL; extract the number (e.g. `#42`) for the next step.
+
+**UI path (when the user wants to review in the browser):**
+
+```bash
+gh issue create --web
+```
+
+Opens `/issues/new/choose` so the user picks the template in the UI, fills in the body, and clicks Submit. Note: `gh issue create --web` does NOT respect `--template` — that flag only applies to the non-web flow (where it's used as starting body text). There is no CLI path to pre-select a template for the web flow; the user has to click the template card in the browser.
+
+**Notes:**
+- The `--body-file` path must point to a file containing the post-template body (frontmatter + guidance comments stripped).
+- If the user has draft body content in a `.plans/*.md` file, extract the single issue's body section and write it to a temp file before passing to `--body-file`.
+
+### Step 6 — Apply relationships
+
+After the issue is created, apply the native GitHub links using the `link-gh-issues` skill (or its underlying helpers):
+
+```bash
+# Link the new issue as a sub-issue of its theme epic
+make gh-sub PARENT=<theme-epic#> CHILDREN="<new-issue#>"
+
+# If the issue is blocked by another
+make gh-block ISSUE=<new-issue#> BLOCKED_BY=<blocker#>
+```
+
+Keep the prose `## Relationships` lines in the body — they coexist with the native links.
+
+### Step 7 — Verify
+
+Confirm the filed issue by URL + a one-line summary. If opening multiple issues from a backlog, echo a mapping:
+
+```
+Draft ID  → GH issue
+OBX-05    → #42   feat(primitives): ...
+OBX-06    → #43   feat(primitives): ...
+```
+
+## Bulk workflow — publishing a wave-backlog
+
+When the user has a `.plans/<wave>-backlog.md` file drafted from `docs/templates/wave-backlog.md`:
+
+1. **Parse** the backlog into discrete issue sections. Each draft starts with `# <title>` followed by `Draft ID: \`<PREFIX>-NN\``. Sections are separated by `---`.
+2. **Identify** which template each draft corresponds to (epic-wave → body starts with `## Goal`; epic-theme → `## Theme`; feature → `## Problem / Request`; design → `## Problem / Question`; research → `## Context` with `## 1.` numbered sections).
+3. **Open the wave epic first** (so its issue number exists before theme epics reference it).
+4. **Open theme epics next** (so their numbers exist before feature / design issues reference them).
+5. **Open leaf issues** (feature / design / bug / research).
+6. **Record** the mapping `<PREFIX>-NN → #issue-number` as you go.
+7. **Replace draft-ID cross-references** in each issue's body with real GH numbers BEFORE creating (so `Parent: OBX-03` becomes `Parent: #41`, etc.). This requires two passes: parse all draft IDs first, create issues, then substitute. OR: create issues with draft IDs as placeholders, then `gh issue edit` each one to rewrite references after all are opened. Either works — the two-pass version keeps each created issue's body already clean.
+8. **Apply native links** using `link-gh-issues` for the whole wave once all issues exist.
+9. **Update the backlog file** — replace draft IDs with GH issue numbers throughout, or archive the file to `.plans/archive/`.
+
+## Common pitfalls
+
+- **Missing label** — `gh issue create --label` fails silently if the label doesn't exist. Run `make gh-labels` first on a fresh repo.
+- **Missing milestone** — same. `gh api repos/:owner/:repo/milestones --method POST -f title="vX.Y-<slug>"` to create.
+- **Template frontmatter in the body** — `gh issue create --body-file` renders the frontmatter block as literal text. Strip the `---` block before writing the temp file.
+- **Shell-escaped backticks** — do NOT escape backticks when passing a body via `--body`. Use `--body-file` with a temp file for any body containing code fences or backticks. Heredocs with single-quoted delimiters (`<<'EOF'`) also preserve backticks correctly.
+- **Wrong milestone number** — milestones are referenced by title (`--milestone "v0.1-diagonal"`), not number. `gh milestone list` (via `gh api`) to confirm titles exist.
+
+## Related skills
+
+- [`link-gh-issues`](./link-gh-issues.md) — Apply native sub-issue and blocked-by links after issues are created. Invoke after this skill finishes creating issues.
+- [`squash-commit`](./squash-commit.md) — Generate a squash commit message when merging an issue's PR.

--- a/.claude/commands/link-gh-issues.md
+++ b/.claude/commands/link-gh-issues.md
@@ -1,0 +1,150 @@
+Apply native GitHub issue relationships (sub-issues and blocked-by) via the GraphQL API.
+
+Use this skill when the user asks to link issues as parent/child (sub-issue hierarchy) or to mark one issue as blocked by another. Works on top of the prose `## Relationships` block convention documented in `docs/contributing.md` — the prose stays as a human-readable record, and this skill applies the matching native link so GitHub's UI and automation pick up the hierarchy.
+
+## When to invoke
+
+- "Link issue #42 as a sub-issue of #7"
+- "Mark #44 as blocked by #43"
+- "Wire up the sub-issues for the Wave 1 theme epic #29"
+- "Apply the relationships from this epic's body" — parse checklist items and parent / blocked-by lines, apply each link
+- "What's blocking #44?" — read relationships via GraphQL
+
+## GitHub features used
+
+| Feature | Mutations | Read fields |
+|---|---|---|
+| Sub-issues (parent ↔ child) | `addSubIssue`, `removeSubIssue`, `reprioritizeSubIssue` | `Issue.parent`, `Issue.subIssues`, `Issue.subIssuesSummary` |
+| Blocked-by / blocking | `addBlockedBy`, `removeBlockedBy` | `Issue.blockedBy`, `Issue.blocking` |
+
+Both available via the GitHub UI (Issue side-panel → Sub-issues / Development) and the `gh api graphql` CLI path.
+
+## Instructions
+
+### Step 1 — Resolve issue numbers to node IDs
+
+Mutations need GraphQL node IDs, not issue numbers. Resolve with:
+
+```bash
+gh api repos/:owner/:repo/issues/<number> --jq .node_id
+```
+
+or via GraphQL for cross-repo cases:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) { id }
+  }
+}' -f owner=<owner> -f name=<name> -F number=<number> --jq .data.repository.issue.id
+```
+
+Cache IDs in bash variables when applying multiple links:
+
+```bash
+PARENT_ID=$(gh api repos/:owner/:repo/issues/7 --jq .node_id)
+CHILD_ID=$(gh api repos/:owner/:repo/issues/42 --jq .node_id)
+```
+
+### Step 2a — Sub-issue link (parent ↔ child)
+
+```bash
+gh api graphql -f query='
+mutation($parent: ID!, $child: ID!) {
+  addSubIssue(input: {issueId: $parent, subIssueId: $child}) {
+    subIssue { number title }
+  }
+}' -f parent="$PARENT_ID" -f child="$CHILD_ID"
+```
+
+Notes:
+- `addSubIssue` also accepts `subIssueUrl` instead of `subIssueId` for cross-repo links.
+- Pass `replaceParent: true` in the input if the child already has a different parent and should be moved.
+- The mutation errors if the link already exists — treat that as no-op.
+
+### Step 2b — Blocked-by link
+
+`addBlockedBy` means "issueId is blocked by blockingIssueId":
+
+```bash
+gh api graphql -f query='
+mutation($this: ID!, $blocker: ID!) {
+  addBlockedBy(input: {issueId: $this, blockingIssueId: $blocker}) {
+    issue { number }
+  }
+}' -f this="$BLOCKED_ID" -f blocker="$BLOCKER_ID"
+```
+
+If the user says "A blocks B", apply `addBlockedBy(issueId=B, blockingIssueId=A)` — this is the inverse form.
+
+### Step 3 — Bulk-apply from an epic body
+
+When applying the relationships from a theme epic or wave epic:
+
+1. Fetch the epic's body: `gh issue view <N> --json body --jq .body`
+2. Parse the `## Issues` (or `## Canonical Child Issues`) checklist: every `#NNN` reference becomes a sub-issue of the epic.
+3. Parse the `## Relationships` block for `Blocked by:` and `Blocks:` lines — apply accordingly.
+4. Skip `Related:` lines — they stay as prose only (no native feature).
+
+Confirm each link applied with a brief summary to the user.
+
+### Step 4 — Verify / read back
+
+```bash
+# Show parent + all sub-issues of an issue
+gh api graphql -f query='
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      title
+      parent { number title }
+      subIssues(first: 50) { nodes { number title state } }
+      subIssuesSummary { total completed percentCompleted }
+      blockedBy(first: 50) { nodes { number title state } }
+      blocking(first: 50) { nodes { number title state } }
+    }
+  }
+}' -f owner=<owner> -f name=<name> -F number=<number>
+```
+
+### Step 5 — Use the helper script when applying many at once
+
+For scripted bulk operations, `.github/scripts/link-issues.sh` wraps the same mutations with a thin CLI:
+
+```bash
+# Link children under a parent
+bash .github/scripts/link-issues.sh sub <parent> <child1> <child2> ...
+
+# Mark one issue blocked by another
+bash .github/scripts/link-issues.sh block <issue> <blocker>
+
+# Or via Makefile
+make gh-sub PARENT=7 CHILDREN="42 43 44"
+make gh-block ISSUE=44 BLOCKED_BY=43
+```
+
+Prefer the script when applying more than two or three links — it handles node-ID resolution and error cases uniformly.
+
+## Common errors
+
+- **`addSubIssue` 422 "already a sub-issue"** — treat as no-op; report to user.
+- **`addBlockedBy` 422 "already blocked by"** — same, no-op.
+- **Node not found** — the issue number is wrong, or the repo doesn't match. Double-check `gh repo view` matches the expected repo.
+- **Missing scope** — the `gh` token needs `repo` scope. `gh auth refresh` if needed.
+
+## What to keep as prose vs native
+
+The prose `## Relationships` block in the issue body is the human-readable record:
+
+```markdown
+## Relationships
+- Parent: #7
+- Blocked by: #42
+- Blocks: #55
+- Related: #38
+```
+
+Leave those lines in place — they're readable in diffs, search, and tools that don't resolve GraphQL. The native link is for GitHub's UI + automation. Both coexist.
+
+`Related:` has no native equivalent; mention only.

--- a/.claude/commands/squash-commit.md
+++ b/.claude/commands/squash-commit.md
@@ -1,0 +1,32 @@
+Generate a squash commit message for a GitHub PR.
+
+## Instructions
+
+1. If an argument is provided (PR number or URL), fetch the PR details using `gh`. Otherwise, detect the current branch and find its open PR.
+2. Fetch all individual commit messages in the PR using `gh api` or `git log`.
+3. Combine them into a single squash commit message following these rules:
+
+### Format
+
+```
+<type>(<scope>): <concise summary of the overall change>
+
+<1-3 sentence description combining the key changes from all commits.
+Focus on the "why" and overall effect, not per-commit details.>
+
+Co-authored-by: <preserve all unique Co-authored-by lines from the individual commits>
+```
+
+### Rules
+
+- Use conventional commit format (`fix`, `feat`, `docs`, `refactor`, `chore`, etc.)
+- The type/scope should reflect the dominant change across all commits
+- Collapse redundant or incremental commits into a single coherent description
+- Preserve ALL unique `Co-authored-by` lines from the individual commits
+- If commits span multiple types (e.g. a fix + a chore), use the most significant type and mention the rest in the body
+- Keep the summary line under 72 characters
+- Do NOT include the individual commit messages as bullet points — this is a squash, not a merge
+
+### Output
+
+Print ONLY the final squash commit message in a code block so the user can copy it directly. Do not add explanation before or after.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,60 @@
+---
+name: Bug report
+about: Something isn't working correctly.
+title: "bug: <short description>"
+labels: ["type:bug"]
+---
+
+## Problem
+<!-- What's broken? One or two sentences. -->
+
+## Reproduction
+```python
+# Minimal reproducing example.
+```
+
+## Expected Behavior
+<!-- What should happen. -->
+
+## Actual Behavior
+<!-- What happens instead. Include traceback if relevant. -->
+
+## Environment
+- Package version:
+- Python:
+- Platform:
+- Key dependency versions:
+
+## References & Existing Code
+- Related code: `<path>`
+- Related issue / PR: #
+
+## Implementation Steps (fix)
+- [ ] Reproduce locally
+- [ ] Root-cause analysis
+- [ ] Fix at `<path>`
+- [ ] Add regression test
+
+## Definition of Done
+- [ ] Regression test captures the bug
+- [ ] Fix lands; regression test green
+- [ ] `make test && make lint && make typecheck` green
+
+## Testing
+- [ ] Regression test at `tests/<path>::<name>` — asserts <what>
+
+## Documentation
+<!-- If user-facing behaviour changed, update relevant pages. -->
+- [ ] N/A, or: update `<path>`
+
+## Relationships
+<!--
+Apply the native GitHub links after the issue is opened:
+  Parent:      make gh-sub PARENT=<parent#> CHILDREN="<this#>"
+  Blocked by:  make gh-block ISSUE=<this#> BLOCKED_BY=<other#>
+  Blocks:      make gh-block ISSUE=<other#> BLOCKED_BY=<this#>
+Helper: `.github/scripts/link-issues.sh` or the `link-gh-issues` skill.
+-->
+- Parent (theme epic, if any): #
+- Blocked by: #
+- Blocks: #

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+# Contact links. Discussions URL is intentionally commented out so that
+# repositories cloned from this template don't misroute support traffic
+# to the template's upstream. Uncomment and replace with your repo's URL
+# once you've enabled Discussions on your project.
+#
+# contact_links:
+#   - name: Question / discussion
+#     url: https://github.com/<owner>/<repo>/discussions
+#     about: Ask a question or start a discussion rather than opening an issue.

--- a/.github/ISSUE_TEMPLATE/design.md
+++ b/.github/ISSUE_TEMPLATE/design.md
@@ -1,0 +1,114 @@
+---
+name: Design / ADR
+about: Resolve an open design question for a new API or architectural decision.
+title: "[Design] <question>"
+labels: ["type:design"]
+---
+
+## Problem / Question
+<!-- The design question being resolved. -->
+
+## User Story
+> As a <role>, I want <capability>, so that <outcome>.
+
+## Motivation
+<!-- Why this needs a decision now. Upstream / downstream consumers. -->
+
+## Proposed Options
+```python
+# Option A
+```
+```python
+# Option B
+```
+
+## Alternatives Considered
+- **Option A** — pros / cons
+- **Option B** — pros / cons
+- **Option C (rejected)** — pros / cons
+
+<!--
+OPTIONAL — Inline context ("Design Snapshot")
+Relevant excerpts from external / private design docs, prior art, or
+existing implementations that inform the decision. Lead with the exact
+signature / snippet; prose last.
+
+Rename the heading to fit the content type: "Prior Art Snippets",
+"Reference Implementations", "Existing Code Excerpt". Delete if N/A.
+-->
+
+## Design Snapshot
+<!-- Delete or rename. -->
+```python
+# Lead with the most relevant prior-art excerpt or API sketch.
+```
+
+<!--
+OPTIONAL — Inline math / numerical context ("Mathematical Notes")
+Equations, sign conventions, numerical considerations that scope the
+decision.
+
+STYLE — prefer unicode math in prose (σ², Λ⁻¹, ∑, O(d³)). Use `text`
+code fences for multi-line equation blocks so pseudo-math isn't mangled
+by syntax highlighting:
+
+    ```text
+    ELBO(λ) = 𝔼_q[ℓ(θ)] − KL(q ‖ p)
+    ∇_λ ELBO = ∇_μ 𝔼[ℓ] − F(λ − λ₀)
+    ```
+
+Rename if the content warrants ("Numerical Considerations",
+"Stability Notes"). Delete if N/A.
+-->
+
+## Mathematical Notes
+<!-- Delete or rename. -->
+```text
+<equations, conventions, edge cases>
+```
+
+## Decision
+<!-- Filled in when the issue is resolved. Short + explicit. -->
+
+## Consequences
+<!-- Ripple effects, downstream changes, back-compat implications. -->
+
+## References & Existing Code
+- Design doc / ADR log: `<path or URL>`
+- Related prior art / issue / PR: #
+
+## Implementation Steps (post-decision)
+- [ ] Land reference implementation at `<path>`
+- [ ] Update ADR log / decisions doc
+- [ ] Open follow-up feature issues if the surface changes
+
+## Definition of Done
+- [ ] Decision + Consequences written into the issue body
+- [ ] ADR entry added to `docs/decisions.md` (or equivalent)
+- [ ] Follow-up feature issues opened and linked
+
+## Testing
+- [ ] Test that encodes the decision (if reference impl lands in the same PR)
+
+## Documentation
+- [ ] ADR page
+- [ ] Docstring notes referencing the decision
+
+## Relationships
+<!--
+Each prose line has a native GitHub feature — apply it after the issue
+is opened so GitHub's UI and automation pick up the hierarchy.
+
+  Parent:      → Sub-issue link.  make gh-sub PARENT=<parent#> CHILDREN="<this#>"
+  Blocked by:  → Typed dependency.  make gh-block ISSUE=<this#> BLOCKED_BY=<other#>
+  Blocks:      → Inverse — apply on the OTHER issue.
+                 make gh-block ISSUE=<other#> BLOCKED_BY=<this#>
+  Related:     → Prose only; no native feature.
+
+Helper: `.github/scripts/link-issues.sh` or the `link-gh-issues` Claude
+Code skill.
+-->
+- Parent (theme epic): #
+- Blocked by: #
+- Blocks: # (issues that can't start until this decision resolves)
+- Related: #

--- a/.github/ISSUE_TEMPLATE/epic-theme.md
+++ b/.github/ISSUE_TEMPLATE/epic-theme.md
@@ -1,0 +1,71 @@
+---
+name: Epic — Theme (L2)
+about: A parallel-safe group of issues under a Wave epic. See docs/contributing.md for the two-layer epic model.
+title: "[EPIC] <theme title>"
+labels: ["type:epic-theme"]
+---
+
+<!--
+A Theme epic is the L2 container under a Wave. It groups several concrete
+issues (features / designs / chores) that ship together as a coherent slice.
+-->
+
+## Theme
+<!-- One-sentence theme / outcome for this group. -->
+
+## Parent Wave
+- Wave epic: #
+- Wave label: `wave:N` (matches the bootstrap label set; swap to `wave:N-<slug>` if you've added descriptive labels)
+- Milestone: `vX.Y-<slug>`
+
+## Motivation
+<!-- Why this group exists; what it ships together. -->
+
+## Issues
+<!--
+Rename to "Canonical Child Issues" if that reads more naturally.
+
+After opening this epic and its children, link each child issue below
+as a SUB-ISSUE of this epic. One-shot:
+    make gh-sub PARENT=<this#> CHILDREN="<child1#> <child2#> <child3#>"
+-->
+- [ ] #<issue> — <short description>
+- [ ] #<issue> — <short description>
+
+<!--
+OPTIONAL — Execution Notes
+Describes ordering / sequencing between child issues inside this theme.
+Useful when some children block others. Examples:
+
+  "#42 lands first because most path rewrites depend on the final
+   module layout. #43 can start once #42's public API is stable."
+
+  "#50 and #51 are fully parallel; #52 depends on both."
+
+Delete this section if the children are fully parallel and no ordering
+decisions need to be recorded.
+-->
+
+## Execution Notes
+<!-- Delete if children are fully parallel. -->
+
+## Parallelism
+- Can run in parallel with: # (other theme epics in the same wave)
+- Blocked by (inside this wave): #
+- Must complete before: #
+
+## Definition of Done
+- [ ] All child issues closed
+- [ ] Tests for the theme's surface land and pass
+- [ ] Docs / API pages for the theme's surface land
+
+## Relationships
+<!--
+After opening, apply native links:
+  Parent (wave):  make gh-sub PARENT=<wave#> CHILDREN="<this#>"
+  Sub-issues:     make gh-sub PARENT=<this#> CHILDREN="<child1#> <child2#>"
+  Blocked by:     make gh-block ISSUE=<this#> BLOCKED_BY=<other-theme#>
+Helper: `.github/scripts/link-issues.sh` or the `link-gh-issues` skill.
+-->
+- Parent: #<wave-epic>
+- Related: #

--- a/.github/ISSUE_TEMPLATE/epic-wave.md
+++ b/.github/ISSUE_TEMPLATE/epic-wave.md
@@ -1,0 +1,70 @@
+---
+name: Epic — Wave (L1)
+about: A release-scoped mega-epic grouping theme epics under one milestone. See docs/contributing.md for the two-layer epic model.
+title: "[EPIC] Wave N: <title>"
+labels: ["type:epic-wave"]
+---
+
+<!--
+A Wave epic is the L1 container for a release / milestone. It groups several
+Theme epics (L2) that can run in parallel. Keep this body short — the
+details live in the Theme epics and their child issues.
+-->
+
+## Goal
+<!-- One sentence: what outcome does this wave deliver? Maps to a milestone / release. -->
+
+## Wave / Milestone
+- Wave: `wave:N` (matches the bootstrap label set; swap to `wave:N-<slug>` if you've added descriptive labels)
+- Milestone: `vX.Y-<slug>`
+
+## Motivation
+<!--
+Why this wave now; what it unlocks; what it blocks.
+
+Rename to "Why This Wave Exists" if a narrative framing fits better
+than pure rationale — useful for waves that exist to undo a historical
+state (e.g. "the repo is still a template, every later wave depends
+on a real package identity").
+-->
+
+## Theme Epics (parallel-safe)
+<!--
+One section per theme. Sections can run in parallel unless noted.
+
+Rename to "Canonical Epics" if you prefer that wording — matches the
+wave-backlog drafting convention in docs/templates/wave-backlog.md.
+
+After the wave epic is opened, each theme epic listed below should also
+be linked as a SUB-ISSUE of this wave. One-shot:
+    make gh-sub PARENT=<this#> CHILDREN="<theme1#> <theme2#> <theme3#>"
+-->
+
+
+### Section A — <theme>
+- [ ] #<theme-epic-issue>
+
+### Section B — <theme>
+- [ ] #<theme-epic-issue>
+
+## Sequential Dependencies
+<!-- e.g. Section A → Section B; Section C can start anytime. -->
+
+## Definition of Done (Wave)
+- [ ] All theme epics closed
+- [ ] Milestone released (tag + changelog)
+- [ ] Tests, lint, format, typecheck all pass on `main`
+- [ ] Docs published
+
+## Relationships
+<!--
+After opening, apply native links:
+  Sub-issues:  each Theme epic above becomes a sub-issue of this wave
+               (make gh-sub PARENT=<this#> CHILDREN="<theme#> <theme#>")
+  Blocked by:  make gh-block ISSUE=<this#> BLOCKED_BY=<prior-wave#>
+  Blocks:      make gh-block ISSUE=<next-wave#> BLOCKED_BY=<this#>
+Helper: `.github/scripts/link-issues.sh` or the `link-gh-issues` skill.
+-->
+- Blocked by: #
+- Blocks: #
+- Related: #

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,128 @@
+---
+name: Feature / Enhancement
+about: A single deliverable that rolls up to a theme epic.
+title: "<scope>: <short description>"
+labels: ["type:feature"]
+---
+
+## Problem / Request
+<!-- What's needed? One or two sentences. -->
+
+## User Story
+> As a <role>, I want <capability>, so that <outcome>.
+
+## Motivation
+<!-- Why now; what it enables; what breaks if we don't have it. -->
+
+## Proposed API
+```python
+# Signatures, types, docstring stubs.
+```
+
+<!--
+OPTIONAL — Inline context ("Design Snapshot")
+Copy here any API signatures, code snippets, configuration examples, or
+excerpts from external / private design docs that the implementer needs to
+work on this issue in isolation. Goal: another contributor (human or AI
+agent) can implement this issue without opening other repos or chats.
+
+RENAME the heading to fit the issue type. Examples:
+  ## Design Snapshot            (typical library feature)
+  ## Demo To Implement          (walkthrough / example / notebook issue)
+  ## Demo Snippet To Include    (docs / API-reference issue)
+  ## Config Snippet             (CI / infra issue)
+  ## Reference Trace            (bug reproduction)
+
+Lead with the exact snippet the implementer will reproduce — prose last.
+Delete this section if not relevant.
+-->
+
+## Design Snapshot
+<!-- Delete or rename. -->
+```python
+# Lead with the exact code/config the implementer will reproduce.
+```
+
+<!--
+OPTIONAL — Inline math / numerical context ("Mathematical Notes")
+For algorithmic / numerical issues: inline equations, sign conventions,
+numerical-stability notes, edge cases. Keep everything the implementer
+needs in one place.
+
+STYLE — prefer unicode math in prose (σ², E₁, ∑, ⊗, ≈, Λ⁻¹, O(d³)) so
+the issue reads in the GH UI and plain-text tools. Reach for a `text`
+code fence for multi-line equation blocks so syntax-highlighting doesn't
+try to parse pseudo-math:
+
+    ```text
+    s_next   = (1 - ρ) * s   + ρ * (s₀   - h)
+    η_next   = (1 - ρ) * η   + ρ * (η₀ + g - h * m)
+    ```
+
+Rename the heading if the content type warrants (e.g. "Numerical Notes",
+"Stability Notes", "Equations To Test"). Delete if not relevant.
+-->
+
+## Mathematical Notes
+<!-- Delete or rename. -->
+```text
+<equations, conventions, numerical considerations>
+```
+
+## References & Existing Code
+- Design doc / spec: `<path or URL>`
+- Reference impl: `<path:line>`
+- Related prior art: `<repo / paper / issue>`
+
+## Implementation Steps
+<!-- Concrete, file-level steps. Each should be checkable. -->
+- [ ] Add `<symbol>` in `src/<package>/<module>.py`
+- [ ] Wire <symbol> into `src/<package>/__init__.py` (if public)
+- [ ] ...
+
+## Definition of Done
+- [ ] Code lands at the intended path
+- [ ] Public API exported via `src/<package>/__init__.py` (if user-facing)
+- [ ] Tests pass: `make test`
+- [ ] Lint + typecheck pass: `make lint && make typecheck`
+- [ ] Docstrings (Google-style) on all public symbols
+
+## Testing
+<!-- One checkbox per test, so progress is trackable. -->
+- [ ] Unit test: `<what it asserts>`
+- [ ] Property / round-trip test: `<what it asserts>` (if applicable)
+- [ ] Regression test: `<what it asserts>` (if applicable)
+
+## Documentation
+- [ ] API reference page / section
+- [ ] Notebook or recipe (if user-facing flow)
+- [ ] Docstrings (covered by Definition of Done)
+
+## Relationships
+<!--
+Each prose line below has a native GitHub feature you should also apply
+after the issue is opened. Keep the prose as a human-readable record AND
+apply the native link so GitHub's UI (sub-issue panel, dependency graph,
+"unblocks on close") works.
+
+  Parent:      → Sub-issue link. UI: Issue side-panel → Sub-issues →
+                 "Create sub-issue" on the parent, or "Convert to
+                 sub-issue" on the child.
+                 CLI: make gh-sub PARENT=<parent#> CHILDREN="<this#>"
+
+  Blocked by:  → Typed dependency. UI: side-panel → Development →
+                 "Mark as blocked by".
+                 CLI: make gh-block ISSUE=<this#> BLOCKED_BY=<other#>
+
+  Blocks:      → Inverse of Blocked by; apply on the OTHER issue.
+                 CLI: make gh-block ISSUE=<other#> BLOCKED_BY=<this#>
+
+  Related:     → No native feature; mention only.
+
+For bulk / scripted linking see `.github/scripts/link-issues.sh` or the
+`link-gh-issues` Claude Code skill (.claude/commands/link-gh-issues.md).
+-->
+- Parent (theme epic): #
+- Blocked by: #
+- Blocks: #
+- Related: #

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,0 +1,195 @@
+---
+name: Research / Comparative Analysis
+about: Investigate an external repo, paper, or prior art and map it onto this project. Produces a prioritized roadmap of follow-up issues.
+title: "research: <short topic>"
+labels: ["type:research"]
+---
+
+<!--
+STYLE NOTES
+- Use unicode math inline in prose (σ², E₁, ∑, ⊗, ≈, Λ⁻¹, ∂/∂x, ℝ, O(d³))
+  rather than LaTeX / MathJax blocks. Keeps the issue readable in the GH UI
+  and in plain-text tools. Reach for `text`-tagged code fences only for
+  multi-line equations or when subscripts are too dense for unicode:
+
+      ```text
+      s_next   = (1 - ρ) * s   + ρ * (s₀   - h)
+      η_next   = (1 - ρ) * η   + ρ * (η₀ + g - h * m)
+      ```
+
+- Numbered top-level sections (## 1. ..., ## 2. ..., etc.) give the issue
+  a citeable table of contents.
+- Letter-then-number subsections (### A., ### B., then #### A1., #### A2.,
+  #### B1., ...) make findings individually linkable ("see A3" reads
+  naturally across the project).
+- Lead tables and code-first sections with the concrete content; keep
+  prose short and after the snippet / table.
+- Delete sections that don't apply. Every placeholder is optional.
+- Rename sections if the content type warrants (e.g. rename §1 to
+  "What `<paper>` Proves" for a theory survey, or §2 to
+  "Comparison with Prior Art" when surveying multiple sources).
+
+Research issues produce the plan; the follow-up feature / design issues
+they open do the actual work.
+-->
+
+# <Title — e.g. "Comparative Analysis: `<external-repo>` vs `<this project>`">
+
+## Context
+
+<!--
+Two short paragraphs. What are we investigating, what's the motivating
+question, and what decision / roadmap does this research inform?
+-->
+
+---
+
+## 1. What `<subject>` Contains
+
+### Package / Project Structure
+```
+<tree or component map, e.g.>
+<subject>/
+├── core/
+│   └── <module>.py
+├── algorithms/
+│   └── <module>.py
+└── utils.py
+```
+
+### Core Data Structures
+
+| Structure | Fields | Purpose |
+|---|---|---|
+| `<name>` | `<fields>` | <role — e.g. Gaussian in square-root form, μ + cholΣ> |
+
+### Core Algorithms / Features
+
+#### A. <Algorithm area — e.g. "Square-root filtering">
+- `<function>(args)` — <what it does>. Complexity O(d³) per step. Returns `(m, cholP)`.
+- `<function>(args)` — <what it does>. Uses the Bonnet–Price identity ∇μ 𝔼[ℓ] = g − Hm.
+
+#### B. <Algorithm area>
+- `<function>(args)` — <what it does>. Parallel via `jax.lax.associative_scan`, gives O(d³ log N) depth on P processors.
+
+---
+
+## 2. Comparison with `<this project>`
+
+### A. Already in `<this project>` (direct equivalents)
+
+| Subject feature | This project's equivalent | Path | Notes |
+|---|---|---|---|
+| `<feature>` | `<our name>` | `src/<path>:<line>` | <gap or divergence> |
+
+### B. Already in `<this project>` but missing enhancements from `<subject>`
+
+#### B1. <Enhancement name> (HIGH PRIORITY)
+- **`<subject>`**: uses <approach>; e.g. σ² = (1/Nd) ∑ rᵢᵀ rᵢ for posterior calibration.
+- **This project**: <current state — what's different, what regresses>.
+- **What's needed**: <concrete change, file paths, function signatures>.
+- **Impact**: <why this matters — correctness / speed / stability>.
+
+#### B2. <Enhancement name> (MEDIUM PRIORITY)
+- ...
+
+### C. Missing completely from `<this project>`
+
+#### C1. <Feature name> (HIGH PRIORITY)
+- **What it is**: <description — e.g. Integrated Wiener Process prior with Nordsieck preconditioner P = diag(dtq+½ / q!) for numerical stability on stiff problems>.
+- **Why useful**: <motivation>.
+- **Where in this project**: proposed module `src/<package>/<submodule>.py`.
+
+#### C2. <Feature name> (MEDIUM PRIORITY)
+- ...
+
+### D. `<this project>` has it, `<subject>` doesn't (context only — no action)
+<!-- Useful to note we haven't regressed on things the subject omits. -->
+- `<our feature>` — <why the subject doesn't need it>.
+
+---
+
+## 3. Summary Table
+
+| Feature | `<subject>` | `<this project>` | Status |
+|---|---|---|---|
+| Sequential filter | ✓ | ✓ | **Already have** |
+| Parallel filter (associative scan) | ✓ | ✗ (dense only) | **Enhancement needed** |
+| Square-root form | ✓ | ✗ | **Missing** |
+| `tria()` QR utility | ✓ | ✗ | **Missing** (dependency for sq-root work) |
+| Block-tridiag operators | ✗ | ✓ | We're ahead |
+
+---
+
+## 4. Recommended Integration Priority
+
+<!-- Phased roadmap. Each phase should be shippable on its own. -->
+
+### Phase 1: Foundations (enables everything else)
+1. <item — e.g. `tria()` lower-triangular QR utility>
+2. <item>
+
+### Phase 2: <theme — e.g. "Square-root Kalman">
+3. <item — e.g. sqrt_predict, sqrt_update, sqrt_smooth primitives>
+
+### Phase 3: <theme — e.g. "Parallel-in-time">
+4. <item>
+
+### Phase 4: <theme>
+5. <item>
+
+### Phase 5: Advanced (nice-to-have)
+6. <item>
+
+---
+
+## 5. Proposed Follow-up Issues
+
+<!--
+Concrete issues to open from this research. These are what actually get
+done. Each should cite the phase / letter-number it resolves, and link
+back to this issue via `Parent research: #<this>`.
+-->
+
+- [ ] `feat(<scope>): add tria() QR utility` — covers Phase 1 item 1 / C8
+- [ ] `feat(<scope>): square-root Kalman primitives` — covers Phase 2 / B2
+- [ ] `[Design] associative-scan element representation` — resolves open question for Phase 3 / C3
+- [ ] `feat(<scope>): IWP prior with Nordsieck preconditioner` — covers Phase 4 / C1
+
+---
+
+## 6. Key Synergies (optional)
+
+<!--
+Narrative section for cross-cutting observations — how combining X with
+Y unlocks Z, architectural implications, dependency chains between the
+missing pieces. Delete if not useful.
+-->
+
+1. **<Synergy name>**: <one paragraph>.
+2. **<Synergy name>**: <one paragraph>.
+
+---
+
+## References
+- <paper / repo / doc> — `<url>`
+- <paper / repo / doc> — `<url>`
+
+## Relationships
+<!--
+Apply native GitHub links after the issue is opened.
+
+  Parent:      → Sub-issue link (research issue nested under a theme epic).
+                 make gh-sub PARENT=<parent#> CHILDREN="<this#>"
+  Blocks:      → Each follow-up issue from §5 should reference THIS research
+                 issue as its blocker. From the follow-up:
+                 make gh-block ISSUE=<follow-up#> BLOCKED_BY=<this#>
+  Blocked by:  → make gh-block ISSUE=<this#> BLOCKED_BY=<other#>
+  Related:     → Prose only; no native feature.
+
+Helper: `.github/scripts/link-issues.sh` or the `link-gh-issues` skill.
+-->
+- Parent (theme epic, if any): #
+- Blocked by: #
+- Blocks (follow-up issues from §5 reference this as parent research): #
+- Related: #

--- a/.github/scripts/create-labels.sh
+++ b/.github/scripts/create-labels.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Bootstrap the standard label taxonomy for this template.
+#
+# Creates labels for: type / area / layer / wave / priority.
+# Idempotent — uses `gh label create --force` so re-runs are safe.
+#
+# Usage:
+#   bash .github/scripts/create-labels.sh
+#   or:
+#   make gh-labels
+#
+# Requires: `gh` CLI authenticated with repo scope.
+#
+# Customise by editing the `create` calls below; run again to apply.
+
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found on PATH. Install from https://cli.github.com/" >&2
+  exit 1
+fi
+
+# Fail early with a clear message if gh is not authenticated.
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh is not authenticated. Run 'gh auth login' first." >&2
+  exit 1
+fi
+
+create() {
+  local name="$1"
+  local color="$2"
+  local desc="$3"
+  gh label create "$name" --color "$color" --description "$desc" --force >/dev/null
+  printf '  ✓ %s\n' "$name"
+}
+
+echo "Creating type:* labels..."
+create "type:epic-wave"   "5319e7" "Release-scoped mega-epic (L1)"
+create "type:epic-theme"  "8b5cf6" "Parallel-safe theme under a wave (L2)"
+create "type:feature"     "a2eeef" "New feature or enhancement"
+create "type:bug"         "d73a4a" "Something isn't working"
+create "type:design"      "fbca04" "Design / ADR issue for a new API"
+create "type:chore"       "c5def5" "Engineering maintenance"
+create "type:docs"        "0075ca" "Documentation work"
+create "type:research"    "bfe5bf" "Comparative analysis / prior-art survey / investigation"
+
+echo "Creating area:* labels..."
+create "area:engineering" "0e8a16" "Build, packaging, CI, tooling"
+create "area:testing"     "bfdadc" "Test suite"
+create "area:docs"        "1d76db" "Docs + notebooks"
+create "area:code"        "c2e0c6" "Source-code changes (catch-all fallback)"
+# Edit / extend for your project. Common domain-specific areas:
+#   area:algorithmic, area:integration, area:performance, area:security
+
+echo "Creating Dependabot / misc labels..."
+create "dependencies" "ededed" "Pull requests that update a dependency file"
+
+echo "Creating layer:* labels (edit to match your project's layer stack)..."
+create "layer:0-primitives" "fef2c0" "Layer 0 — pure primitives"
+create "layer:1-components" "fbca04" "Layer 1 — components / services"
+create "layer:2-models"     "d4c5f9" "Layer 2 — public API / wrappers"
+
+echo "Creating wave:* labels (edit to match your release plan)..."
+# Plain `wave:N` scheme — simple and matches the label format referenced in
+# the epic issue templates. If you prefer descriptive slugs, add extras like
+# `wave:0-bootstrap`, `wave:1-mvp` alongside the numeric base.
+create "wave:0" "c2e0c6" "Wave 0"
+create "wave:1" "bfd4f2" "Wave 1"
+create "wave:2" "d4c5f9" "Wave 2"
+create "wave:3" "f9d0c4" "Wave 3"
+create "wave:4" "fef2c0" "Wave 4"
+
+echo "Creating priority:* labels..."
+create "priority:p0" "b60205" "Blocker for current wave"
+create "priority:p1" "d93f0b" "High priority"
+create "priority:p2" "fbca04" "Normal priority"
+
+echo
+echo "Done. View labels: gh label list"

--- a/.github/scripts/link-issues.sh
+++ b/.github/scripts/link-issues.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Apply native GitHub issue relationships via the GraphQL API.
+#
+# Supports two relationship types:
+#   - sub-issues (parent <-> child hierarchy)
+#   - blocked-by / blocks (typed dependency)
+#
+# Usage:
+#   bash .github/scripts/link-issues.sh sub <parent> <child> [<child> ...]
+#   bash .github/scripts/link-issues.sh block <issue> <blocking-issue>
+#   bash .github/scripts/link-issues.sh unsub <parent> <child>
+#   bash .github/scripts/link-issues.sh unblock <issue> <blocking-issue>
+#   bash .github/scripts/link-issues.sh show <issue>
+#
+# All issue arguments are numeric (e.g. 42), resolved to node IDs automatically.
+#
+# Or via Makefile:
+#   make gh-sub PARENT=7 CHILDREN="42 43 44"
+#   make gh-block ISSUE=44 BLOCKED_BY=43
+#
+# Requires: `gh` CLI authenticated with repo scope.
+
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found on PATH. Install from https://cli.github.com/" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: gh is not authenticated. Run 'gh auth login' first." >&2
+  exit 1
+fi
+
+# Resolve issue number -> node ID in the current repo.
+node_id_for() {
+  local number="$1"
+  gh api "repos/:owner/:repo/issues/${number}" --jq '.node_id' 2>/dev/null \
+    || { echo "error: could not resolve issue #${number} — wrong repo or number?" >&2; return 1; }
+}
+
+# Link one child under a parent. Idempotent: reports no-op if already linked.
+add_sub_issue() {
+  local parent="$1" child="$2"
+  local parent_id child_id
+  parent_id=$(node_id_for "$parent")
+  child_id=$(node_id_for "$child")
+
+  local out
+  if out=$(gh api graphql \
+      -f query='mutation($p: ID!, $c: ID!) { addSubIssue(input: {issueId: $p, subIssueId: $c}) { subIssue { number } } }' \
+      -f p="$parent_id" -f c="$child_id" 2>&1); then
+    printf '  ✓ sub-issue: #%s -> parent #%s\n' "$child" "$parent"
+  else
+    if grep -qiE "already|duplicate" <<<"$out"; then
+      printf '  • no-op: #%s is already a sub-issue of #%s\n' "$child" "$parent"
+    else
+      printf '  ✗ failed #%s -> #%s: %s\n' "$child" "$parent" "$out" >&2
+      return 1
+    fi
+  fi
+}
+
+remove_sub_issue() {
+  local parent="$1" child="$2"
+  local parent_id child_id
+  parent_id=$(node_id_for "$parent")
+  child_id=$(node_id_for "$child")
+  gh api graphql \
+    -f query='mutation($p: ID!, $c: ID!) { removeSubIssue(input: {issueId: $p, subIssueId: $c}) { issue { number } } }' \
+    -f p="$parent_id" -f c="$child_id" >/dev/null
+  printf '  ✓ removed sub-issue link: #%s -/> #%s\n' "$child" "$parent"
+}
+
+# Mark `issue` as blocked by `blocker`.
+add_blocked_by() {
+  local issue="$1" blocker="$2"
+  local issue_id blocker_id
+  issue_id=$(node_id_for "$issue")
+  blocker_id=$(node_id_for "$blocker")
+
+  local out
+  if out=$(gh api graphql \
+      -f query='mutation($i: ID!, $b: ID!) { addBlockedBy(input: {issueId: $i, blockingIssueId: $b}) { issue { number } } }' \
+      -f i="$issue_id" -f b="$blocker_id" 2>&1); then
+    printf '  ✓ #%s is now blocked by #%s\n' "$issue" "$blocker"
+  else
+    if grep -qiE "already|duplicate" <<<"$out"; then
+      printf '  • no-op: #%s is already blocked by #%s\n' "$issue" "$blocker"
+    else
+      printf '  ✗ failed #%s blocked-by #%s: %s\n' "$issue" "$blocker" "$out" >&2
+      return 1
+    fi
+  fi
+}
+
+remove_blocked_by() {
+  local issue="$1" blocker="$2"
+  local issue_id blocker_id
+  issue_id=$(node_id_for "$issue")
+  blocker_id=$(node_id_for "$blocker")
+  gh api graphql \
+    -f query='mutation($i: ID!, $b: ID!) { removeBlockedBy(input: {issueId: $i, blockingIssueId: $b}) { issue { number } } }' \
+    -f i="$issue_id" -f b="$blocker_id" >/dev/null
+  printf '  ✓ removed blocked-by: #%s no longer blocked by #%s\n' "$issue" "$blocker"
+}
+
+# Print parent / sub-issues / blocking / blocked-by for an issue.
+show_issue() {
+  local number="$1"
+  local owner repo
+  owner=$(gh repo view --json owner --jq '.owner.login')
+  repo=$(gh repo view --json name --jq '.name')
+  gh api graphql \
+    -f query='
+query($o: String!, $n: String!, $num: Int!) {
+  repository(owner: $o, name: $n) {
+    issue(number: $num) {
+      number title state
+      parent { number title state }
+      subIssues(first: 50) { nodes { number title state } }
+      subIssuesSummary { total completed percentCompleted }
+      blockedBy(first: 50) { nodes { number title state } }
+      blocking(first: 50) { nodes { number title state } }
+    }
+  }
+}' -f o="$owner" -f n="$repo" -F num="$number"
+}
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  sub)
+    [[ $# -ge 2 ]] || usage
+    parent="$1"; shift
+    for child in "$@"; do
+      add_sub_issue "$parent" "$child"
+    done
+    ;;
+  unsub)
+    [[ $# -eq 2 ]] || usage
+    remove_sub_issue "$1" "$2"
+    ;;
+  block)
+    [[ $# -eq 2 ]] || usage
+    add_blocked_by "$1" "$2"
+    ;;
+  unblock)
+    [[ $# -eq 2 ]] || usage
+    remove_blocked_by "$1" "$2"
+    ;;
+  show)
+    [[ $# -eq 1 ]] || usage
+    show_issue "$1"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,3 @@
+# Code Review Skill
+
+Use `/CODE_REVIEW.md` for repository-specific review criteria.

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,318 @@
+# Code Review Agent Instructions
+
+Standing instructions for **all** agents performing code reviews on this repository.
+
+---
+
+## How to Obtain the Diff
+
+Use the following command to get the diff for review:
+
+```bash
+BASE_BRANCH="$(git rev-parse --verify main >/dev/null 2>&1 && echo main || echo master)"
+git --no-pager diff --no-prefix --unified=100000 --minimal $(git merge-base --fork-point "$BASE_BRANCH")...HEAD
+```
+
+If that fails (e.g. detached HEAD, shallow clone), fall back to:
+
+```bash
+git --no-pager diff --no-prefix --unified=100000 --minimal "$BASE_BRANCH"...HEAD
+```
+
+### Reading the diff
+
+| Prefix | Meaning |
+|--------|---------|
+| `+` | Added line |
+| `-` | Removed line |
+| ` ` (space) | Unchanged context |
+| `@@` | Hunk header |
+
+---
+
+## Review Checklist
+
+### 1. Code Style and Readability
+
+- Clear, descriptive naming (variables, functions, classes, modules)
+- Appropriate function/method length (single responsibility)
+- Logical code organization and flow
+- Avoidance of deeply nested structures
+- Linting via **ruff** (`uv run --group lint ruff check .`) — lint the **entire repo**, not just the package
+- Type-hint checking via **ty** (`uv run --group typecheck ty check src/mypackage`)
+
+> **Rule of thumb**: Sacrifice *cleverness* for *clarity*. Sacrifice *brevity* for *explicitness*.
+> Don't worry about formatting — our CI pipeline (ruff format, pre-commit) handles that automatically.
+
+### 2. Modern Python Idioms (Python ≥ 3.12)
+
+- `from __future__ import annotations` at the top of every module
+- Type hints on **all** public functions, methods, and module-level variables
+- `pathlib.Path` over `os.path`
+- f-strings for string formatting
+- Walrus operator (`:=`) only when it genuinely improves readability
+- `match` statements for pattern matching where appropriate
+- Structural pattern matching for complex conditionals
+- Context managers (`with` statements) for resource handling
+- `dataclasses` or `attrs` for data containers
+- `Enum` for fixed sets of constants
+- Modern union syntax (`X | Y` instead of `Union[X, Y]`)
+- Modern optional syntax (`X | None` instead of `Optional[X]`)
+- Built-in generics (`list[int]`, `dict[str, Any]` instead of `List[int]`, `Dict[str, Any]`)
+
+### 3. Packaging and Project Structure
+
+- Proper `pyproject.toml` configuration (PEP 621)
+- Appropriate use of `__init__.py` exports
+- Clear module boundaries and dependencies
+- Correct use of relative vs absolute imports
+- Entry points defined properly for CLI tools
+- `src/` layout enforced
+
+### 4. Documentation
+
+- Module-level docstrings explaining purpose
+- Function/method docstrings for **all** public APIs (Google style — be consistent)
+- Inline comments explaining *why*, not *what* — except for complex logic or function calls where a brief *what* comment aids comprehension
+- Complex algorithms should have step-by-step explanations
+- All scientific algorithms should include Unicode equations in docstrings and inline where appropriate (e.g. `# σ² = Σ(xᵢ − μ)² / N`)
+- All docstrings for public classes and functions should include 2–3 example use cases
+- Type hints serve as documentation — ensure they are accurate and complete
+
+### 5. Error Handling
+
+- Specific exception types (never bare `except:`)
+- Custom exceptions for domain-specific errors
+- Helpful error messages with context
+- Proper exception chaining (`raise ... from ...`)
+- Early returns / guard clauses to reduce nesting
+
+### 6. Testing Considerations
+
+- Functions should be easily testable (pure functions where possible)
+- Dependencies should be injectable
+- Side effects should be isolated and explicit
+- Consider edge cases and boundary conditions
+
+### 7. Performance (when relevant)
+
+- Appropriate data structures for the use case
+- Generator expressions for large sequences
+- Avoid premature optimization
+- Note O(n) implications for critical paths
+
+### 8. Security
+
+- No hardcoded secrets or credentials
+- Input validation and sanitization
+- Safe handling of file paths (no path traversal vulnerabilities)
+- Appropriate use of `subprocess` (avoid `shell=True`)
+
+---
+
+## Package Preferences
+
+When reviewing dependency choices or suggesting alternatives, prefer these libraries:
+
+| Purpose | Preferred Package |
+|---------|-------------------|
+| Logging | `loguru` |
+| CLI | `cyclopts` |
+| Data containers | `dataclasses` (stdlib) or `attrs` |
+| Configuration | `hydra-core` / `omegaconf` |
+| Path handling | `pathlib` (stdlib) |
+| HTTP | `httpx` |
+| Testing | `pytest` |
+
+---
+
+## Python-Specific Checks
+
+When reviewing, specifically verify the patterns below.
+
+### Type Hints
+
+```python
+# ❌ Missing type hints
+def process_data(items, threshold):
+    ...
+
+# ✅ Complete type hints
+def process_data(items: list[DataItem], threshold: float) -> ProcessedResult:
+    ...
+```
+
+### Modern Syntax
+
+```python
+# ❌ Old-style
+from typing import Optional, Union, List, Dict
+
+def fetch(id: Optional[int] = None) -> Union[Data, None]:
+    result: Dict[str, List[int]] = {}
+
+# ✅ Modern (Python 3.12+)
+from __future__ import annotations
+
+def fetch(id: int | None = None) -> Data | None:
+    result: dict[str, list[int]] = {}
+```
+
+### Dataclasses for Data Containers
+
+```python
+# ❌ Plain class with boilerplate
+class Config:
+    def __init__(self, host: str, port: int, timeout: float = 30.0):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+# ✅ Dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+@dataclass
+class Config:
+    host: str
+    port: int
+    timeout: float = 30.0
+```
+
+### Path Handling
+
+```python
+# ❌ os.path
+import os
+path = os.path.join(base_dir, "data", filename)
+if os.path.exists(path):
+    with open(path) as f:
+        ...
+
+# ✅ pathlib
+from pathlib import Path
+path = base_dir / "data" / filename
+if path.exists():
+    content = path.read_text()
+```
+
+### Exception Handling
+
+```python
+# ❌ Bare except, poor chaining
+try:
+    result = parse(data)
+except:
+    raise RuntimeError("Failed")
+
+# ✅ Specific exceptions, proper chaining
+try:
+    result = parse(data)
+except json.JSONDecodeError as e:
+    raise ParseError(f"Invalid JSON in {source}") from e
+```
+
+### Explanatory Comments for Complex Logic
+
+```python
+# ❌ No explanation for non-obvious algorithm
+def calculate_score(items):
+    return sum(i.weight * (1 - i.age / 365) for i in items if i.active)
+
+# ✅ Clear explanation of the logic
+def calculate_score(items: list[Item]) -> float:
+    """Calculate weighted score with time decay.
+
+    Score computation:
+        1. Filter to only active items
+        2. Apply time decay: items lose relevance linearly over one year
+        3. Weight each item's contribution by its assigned weight
+        4. Sum all weighted, decayed values
+    """
+    total = 0.0
+    for item in items:
+        if not item.active:
+            continue
+        # Time decay factor: 1.0 for new items → 0.0 after 365 days
+        decay_factor = 1 - (item.age / 365)
+        total += item.weight * decay_factor
+    return total
+```
+
+---
+
+## Output Format
+
+Format each review using this structure:
+
+````
+# Code Review for ${feature_description}
+
+Overview of the changes, including the purpose, context, and files involved.
+
+## Suggestions
+
+### ${emoji} ${Summary of suggestion with necessary context}
+
+* **Priority**: ${priority_emoji} ${priority_label}
+* **File**: `${relative/path/to/file.py}`
+* **Line(s)**: ${line_numbers}
+* **Details**: Explanation of the issue and why it matters
+* **Current Code**:
+  ```python
+  # problematic code
+  ```
+* **Suggested Change**:
+  ```python
+  # improved code with explanation
+  ```
+
+### (additional suggestions…)
+
+## Summary
+
+Brief summary of overall code quality and key action items.
+````
+
+---
+
+## Priority Levels
+
+| Emoji | Level | Use when |
+|-------|-------|----------|
+| 🔥 | **Critical** | Bugs, security issues, or code that will fail |
+| ⚠️ | **High** | Significant issues affecting maintainability or correctness |
+| 🟡 | **Medium** | Improvements for code quality or consistency |
+| 🟢 | **Low** | Minor polish or optional enhancements |
+
+## Suggestion Type Emojis
+
+Prefix each suggestion title with a type indicator:
+
+| Emoji | Type |
+|-------|------|
+| 🐛 | Bug or potential bug |
+| 🔒 | Security concern |
+| 🔧 | Change request (must fix) |
+| ♻️ | Refactor suggestion |
+| 📝 | Documentation improvement |
+| 🎨 | Style / formatting issue |
+| ⚡ | Performance consideration |
+| 🧪 | Testing suggestion |
+| ❓ | Question or clarification needed |
+| ⛏️ | Nitpick (very minor) |
+| 💭 | Design consideration |
+| 👍 | Positive feedback (highlight good patterns) |
+| 🌱 | Future consideration (not blocking) |
+
+---
+
+## Review Tone
+
+- Be **constructive** and **specific**
+- **Acknowledge** good patterns and decisions (use 👍 liberally)
+- Explain the *why* behind every suggestion
+- Offer **concrete alternatives**, not just criticism
+- Recognize that context matters — ask clarifying questions when needed
+- Keep feedback **actionable**: every suggestion should have a clear next step

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -39,7 +39,7 @@ git --no-pager diff --no-prefix --unified=100000 --minimal "$BASE_BRANCH"...HEAD
 - Logical code organization and flow
 - Avoidance of deeply nested structures
 - Linting via **ruff** (`uv run --group lint ruff check .`) — lint the **entire repo**, not just the package
-- Type-hint checking via **ty** (`uv run --group typecheck ty check src/mypackage`)
+- Type-hint checking via **ty** (`uv run --group typecheck ty check src/gauss_flows`, or `make typecheck`)
 
 > **Rule of thumb**: Sacrifice *cleverness* for *clarity*. Sacrifice *brevity* for *explicitness*.
 > Don't worry about formatting — our CI pipeline (ruff format, pre-commit) handles that automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+See the full contributor guide at [docs/contributing.md](docs/contributing.md) for:
+
+- Label taxonomy (`type:*`, `area:*`, `layer:*`, `wave:*`, `priority:*`)
+- Two-layer epic model (**Wave → Theme → Issue**)
+- Issue format conventions (`.github/ISSUE_TEMPLATE/`)
+- Relationships syntax (`Parent:`, `Blocked by:`, `Blocks:`, `Related:`)
+- Pre-commit checklist and quality gates
+
+Bootstrap the standard label set for a fresh clone of this template:
+
+```bash
+make gh-labels
+```
+
+Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) spec — enforced on PR titles by CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ See the full contributor guide at [docs/contributing.md](docs/contributing.md) f
 - Relationships syntax (`Parent:`, `Blocked by:`, `Blocks:`, `Related:`)
 - Pre-commit checklist and quality gates
 
-Bootstrap the standard label set for a fresh clone of this template:
+Bootstrap the standard label set for a fresh clone of this repo:
 
 ```bash
 make gh-labels

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ check-env-%:
 # Phony declarations
 # ---------------------------------------------------------------------------
 .PHONY: help install init lint format typecheck test test-fast test-cov \
-        precommit build clean version docs docs-serve docs-deploy
+        precommit build clean version docs docs-serve docs-deploy \
+        gh-labels gh-sub gh-block gh-show
 
 .DEFAULT_GOAL := help
 
@@ -179,3 +180,24 @@ docs-serve: ## 🌐 Serve documentation locally
 
 docs-deploy: ## 🚀 Deploy documentation to GitHub Pages
 	uv run --group docs mkdocs gh-deploy --force
+
+# ===========================================================================
+##@ GitHub
+# ===========================================================================
+
+gh-labels: ## 🏷️  Bootstrap the GitHub label taxonomy (type / area / layer / wave / priority)
+	bash .github/scripts/create-labels.sh
+
+gh-sub: ## 🔗 Link CHILDREN as sub-issues of PARENT (e.g. make gh-sub PARENT=7 CHILDREN="42 43 44")
+	@test -n "$(PARENT)"   || { echo "error: PARENT=<issue-number> required"   >&2; exit 1; }
+	@test -n "$(CHILDREN)" || { echo "error: CHILDREN=\"<a> <b> ...\" required" >&2; exit 1; }
+	bash .github/scripts/link-issues.sh sub $(PARENT) $(CHILDREN)
+
+gh-block: ## 🚧 Mark ISSUE as blocked by BLOCKED_BY (e.g. make gh-block ISSUE=44 BLOCKED_BY=43)
+	@test -n "$(ISSUE)"      || { echo "error: ISSUE=<issue-number> required"      >&2; exit 1; }
+	@test -n "$(BLOCKED_BY)" || { echo "error: BLOCKED_BY=<issue-number> required" >&2; exit 1; }
+	bash .github/scripts/link-issues.sh block $(ISSUE) $(BLOCKED_BY)
+
+gh-show: ## 🔍 Show parent / sub-issues / blocking / blocked-by for ISSUE
+	@test -n "$(ISSUE)" || { echo "error: ISSUE=<issue-number> required" >&2; exit 1; }
+	bash .github/scripts/link-issues.sh show $(ISSUE)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,240 @@
+# Contributing
+
+This page documents the label taxonomy, epic model, and issue conventions used in this project.
+
+---
+
+## Label Taxonomy
+
+Every issue carries exactly one `type:*`, one or more `area:*`, at most one `layer:*`, one `wave:*`, and one `priority:*`.
+
+| Scope | Labels |
+|---|---|
+| **Type** | `type:epic-wave`, `type:epic-theme`, `type:feature`, `type:design`, `type:chore`, `type:docs`, `type:bug`, `type:research` |
+| **Area** | `area:engineering`, `area:testing`, `area:docs`, `area:code` — extend per project (e.g. `area:algorithmic`, `area:integration`) |
+| **Layer** | `layer:0-primitives`, `layer:1-components`, `layer:2-models` — only if the project has a formal layer stack |
+| **Wave** | `wave:0`, `wave:1`, `wave:2`, … — release-scoped phases (add `wave:N-<slug>` variants for descriptive labels) |
+| **Priority** | `priority:p0` (blocker), `priority:p1` (high), `priority:p2` (normal) |
+
+Bootstrap the standard set on a fresh repo:
+
+```bash
+make gh-labels
+```
+
+The script lives at `.github/scripts/create-labels.sh`. Edit the hard-coded `create …` entries in the script to customise `area:*`, `layer:*`, and `wave:*` for the project, then re-run — the script is idempotent.
+
+---
+
+## Two-Layer Epic Model
+
+Work is organised as **Wave → Theme → Issue**:
+
+```
+[EPIC] Wave N   (L1)   —   release-scoped mega-epic, owns a milestone
+  ├── [EPIC] <theme>   (L2)   —   parallel-safe group of issues
+  │     ├── feature / design / chore / bug issue
+  │     └── …
+  └── [EPIC] <theme>   (L2)
+        └── …
+```
+
+- **Wave epic** (`type:epic-wave`) maps one-to-one with a milestone (`vX.Y-<slug>`). Groups several Theme epics that can run in parallel.
+- **Theme epic** (`type:epic-theme`) groups concrete issues that ship together as a coherent slice. Themes inside a wave are parallel-safe unless the body says otherwise.
+- **Issue** (feature / design / chore / bug) is the leaf — a single substantial deliverable that rolls up to a Theme epic.
+
+Stragglers are discouraged: any `type:feature` issue should attach to a Theme epic. If no suitable theme exists, create one first.
+
+---
+
+## Issue Format
+
+Issue templates live in `.github/ISSUE_TEMPLATE/`:
+
+| Template | When to use |
+|---|---|
+| `Epic — Wave (L1)` | Opening a new release-scoped wave |
+| `Epic — Theme (L2)` | Grouping related issues inside a wave |
+| `Feature / Enhancement` | One substantial deliverable |
+| `Design / ADR` | Resolve an open design question for a new API |
+| `Bug report` | Something isn't working |
+| `Research / Comparative Analysis` | Study prior art (external repo, paper) and produce a prioritized roadmap of follow-up issues |
+
+Feature + Design templates include two **optional** sections for context-heavy issues:
+
+- **Design Snapshot** — paste API sketches, code examples, or excerpts from private / external design docs so the issue is self-contained.
+- **Mathematical Notes** — equations, sign conventions, numerical considerations.
+
+Delete either section if not relevant. Both exist so that an implementer (human or AI agent) can work on the issue without opening other repos or channels.
+
+---
+
+## Creating issues
+
+New issues should use one of the templates in `.github/ISSUE_TEMPLATE/` so that labels, required sections, and title conventions are consistent.
+
+### From the UI
+
+Click **New issue** on the repo's Issues tab and pick a template. The body is pre-filled with the section scaffolding — fill in, apply labels and milestone, submit.
+
+### From the CLI
+
+For drafted content, write the body to a file (minus the template's YAML frontmatter), then:
+
+```bash
+gh issue create \
+  --title "feat(primitives): diagonal BLR update step" \
+  --body-file /tmp/issue-body.md \
+  --label "type:feature,area:algorithmic,layer:0-primitives,wave:1,priority:p1" \
+  --milestone "v0.1-diagonal"
+```
+
+To open the UI in a browser with a template pre-selected:
+
+```bash
+gh issue create --web
+```
+
+The web flow opens `/issues/new/choose` so you can pick the template in the UI. `gh issue create` does not support pre-selecting a template for the web path; the `--template` flag is only used as starting body text in the non-web flow.
+
+After the issue is created, apply native parent / blocked-by links via the Makefile targets documented below in the Relationships section (or `make gh-sub` / `make gh-block`).
+
+### From Claude Code
+
+The `create-gh-issue` skill (at `.claude/commands/create-gh-issue.md`) guides Claude through:
+
+- **Picking the right template** (decision tree covering feature / design / bug / research / epic-wave / epic-theme)
+- **Drafting the body** with required sections + rename guidance for optional sections (`Design Snapshot` → `Demo To Implement`, etc.)
+- **Applying the correct label set** (which `type:*` + `area:*` + `layer:*` + `wave:*` + `priority:*` combos are valid for each work type)
+- **Setting the milestone** (which `vX.Y-<slug>` corresponds to the wave)
+- **Applying relationships** (chains to `link-gh-issues` skill for native sub-issue + blocked-by links)
+- **Style conventions** — unicode math, `text` code fences, code-first-prose-last
+- **Bulk workflow** — publishing a `.plans/<wave>-backlog.md` file into real GitHub issues (multi-pass: wave epic → theme epics → leaf issues → relationships), with draft-ID → GH-number mapping
+
+Example prompts:
+
+- "Open a feature issue for the diagonal BLR update step, child of theme epic #27"
+- "File a design issue for the per-parameter prior question"
+- "Publish the drafts in `.plans/wave-1-backlog.md` as real issues and wire up the sub-issue links"
+- "Open a research issue comparing pof vs this project, based on my notes in `<path>`"
+
+---
+
+## Drafting a wave backlog
+
+For large planning exercises (new wave, new release, large refactor), draft the whole backlog as one markdown file **before** opening GitHub issues. A template lives at [`docs/templates/wave-backlog.md`](templates/wave-backlog.md).
+
+Why:
+
+- **Review the whole wave in one scroll** instead of clicking through 15 half-drafted issues
+- **Share context once** at the top (Shared Context · Design Snapshot · Intended Package Layout · Runtime Boundary) rather than duplicating across every child issue
+- **Stable draft IDs** (`<PREFIX>-01`, `<PREFIX>-02`, …) let child issues reference each other before GitHub issue numbers exist
+
+Workflow:
+
+1. Copy `docs/templates/wave-backlog.md` into your project's `.plans/` directory (gitignored). Rename to describe the wave — e.g. `.plans/wave-1-backlog.md`.
+2. Pick a short project prefix (e.g. `PYX` for pyrox, `OBX` for optax_bayes). Number drafts sequentially.
+3. Fill in shared context at the top, then draft each issue body.
+4. When the file is ready, open each draft as a real GitHub issue using the matching `.github/ISSUE_TEMPLATE/`. Copy the body verbatim.
+5. Record GitHub issue numbers next to draft IDs in the backlog file, or replace draft IDs throughout. Update cross-references.
+6. Either delete the backlog file or archive it in `.plans/archive/`.
+
+---
+
+## Relationships
+
+Use an explicit `## Relationships` block at the bottom of each issue / epic body:
+
+```markdown
+## Relationships
+- Parent: #<theme-epic>
+- Blocked by: #
+- Blocks: #
+- Related: #
+```
+
+GitHub's task-list feature links bidirectionally from the parent, so checklist items in a Theme epic body auto-show in the referenced issues.
+
+### Applying native GitHub relationships
+
+The prose `## Relationships` block above is a human-readable record. GitHub also exposes two **native** relationship features that power the UI sub-issue panel and the dependency graph — **apply both**:
+
+| Prose line | Native feature | Mutation |
+|---|---|---|
+| `Parent:` / `Theme Epics` / `Issues` checklist | Sub-issues (parent ↔ child hierarchy) | `addSubIssue` / `removeSubIssue` |
+| `Blocked by:` | Typed dependency | `addBlockedBy` |
+| `Blocks:` | Inverse — applied on the OTHER issue | `addBlockedBy` (on the blocked side) |
+| `Related:` | No native feature | prose only |
+
+#### From the UI
+
+- **Sub-issues** — open the parent issue, side-panel → *Sub-issues* → *Create sub-issue* or *Add existing sub-issue*.
+- **Blocked by** — open the blocked issue, side-panel → *Development* → *Mark as blocked by*.
+
+#### From the CLI (Makefile targets)
+
+For scripted work, the repo ships a helper script wrapped by three `make` targets:
+
+```bash
+# Link children as sub-issues under a parent
+make gh-sub PARENT=7 CHILDREN="42 43 44"
+
+# Mark issue 44 as blocked by 43
+make gh-block ISSUE=44 BLOCKED_BY=43
+
+# Inspect parent / sub-issues / blocking / blocked-by for an issue
+make gh-show ISSUE=44
+```
+
+Direct script usage (same functionality plus unlink commands):
+
+```bash
+bash .github/scripts/link-issues.sh sub     <parent> <child> [<child> ...]
+bash .github/scripts/link-issues.sh block   <issue> <blocker>
+bash .github/scripts/link-issues.sh unsub   <parent> <child>
+bash .github/scripts/link-issues.sh unblock <issue> <blocker>
+bash .github/scripts/link-issues.sh show    <issue>
+```
+
+The script resolves issue numbers to GraphQL node IDs automatically, and treats "already linked" as a no-op so re-runs are safe.
+
+#### From Claude Code
+
+The `link-gh-issues` skill (at `.claude/commands/link-gh-issues.md`) guides Claude through the same operations — useful for bulk-applying relationships from a drafted wave backlog, parsing the `Issues` checklist out of a theme epic body, or verifying that the native links match the prose.
+
+Example prompts:
+
+- "Apply the relationships from epic #29"
+- "Link #42, #43, #44 as sub-issues of #7"
+- "Mark #44 as blocked by #43"
+- "What's blocking #44?" (Claude runs `make gh-show ISSUE=44` or the underlying GraphQL query)
+
+#### Raw GraphQL (for reference)
+
+Under the hood the helper runs:
+
+```graphql
+mutation { addSubIssue(input: { issueId: "<parent-node-id>", subIssueId: "<child-node-id>" }) { subIssue { number } } }
+mutation { addBlockedBy(input: { issueId: "<this-node-id>", blockingIssueId: "<blocker-node-id>" }) { issue { number } } }
+```
+
+Issue node IDs are resolved via `gh api repos/:owner/:repo/issues/<N> --jq .node_id`.
+
+---
+
+## Pre-commit checklist
+
+Run these locally before opening a PR:
+
+```bash
+make format       # ruff format . + ruff check --fix .   (applies changes)
+make lint         # ruff check .                         (CI-style check)
+make typecheck    # ty check
+make test         # pytest
+```
+
+Note that `make format` **mutates files** — it formats and applies autofixes. `make lint` is the CI-parity read-only check. Run `make format` first, commit the result, then run `make lint` / `make test` to verify.
+
+Pre-commit hooks run ruff on every commit. Run `make precommit` to apply them to all files manually.
+
+Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification — enforced on PR titles by `.github/workflows/conventional-commits.yml`.

--- a/docs/templates/wave-backlog.md
+++ b/docs/templates/wave-backlog.md
@@ -1,0 +1,341 @@
+<!--
+WAVE BACKLOG DRAFT — COPY-TO-USE TEMPLATE
+
+Purpose:
+  Draft a whole wave of GitHub issues as one reviewable markdown file
+  BEFORE opening the issues. Keeps shared context in one place, uses
+  stable draft IDs so children can cross-reference each other, and
+  lets the whole backlog be reviewed in a single scroll.
+
+How to use:
+  1. Copy this file into your project's `.plans/` directory
+     (gitignored). Rename to describe the wave, e.g.
+     `.plans/wave-1-diagonal-backlog.md`.
+  2. Pick a short project prefix (e.g. PYX for pyrox, OBX for
+     optax_bayes) and number drafts sequentially: <PREFIX>-01,
+     <PREFIX>-02, … Draft IDs survive the draft→publish conversion
+     so references between issues remain meaningful.
+  3. Fill in the wave-level shared context once at the top, then
+     draft each issue body. Review the whole file as a unit.
+  4. When ready, open each draft as a real GitHub issue using the
+     matching .github/ISSUE_TEMPLATE — the epic-wave, epic-theme,
+     feature, design, bug, and research templates all take bodies
+     compatible with what this file produces.
+  5. After publishing, either delete this file or replace draft IDs
+     with the assigned GitHub issue numbers to keep the record.
+
+Conventions:
+  - For algorithmic / numerical issues, math is part of the spec, not
+    decoration. Include the equations another implementer will need:
+    update rules, factorization identities, sign conventions,
+    approximations, and invariants to test.
+  - Use normal GitHub math syntax for issue-ready drafts:
+    inline `$...$`, display `$$...$$`.
+  - Unicode math in prose (σ², ∑, Λ⁻¹, O(d³)) is also encouraged when
+    it improves readability in plain text.
+  - Delete sections that don't apply. Every header below is optional
+    except Wave Goal, one Theme Epic, and one child issue.
+  - Rename headings to fit the content (see .github/ISSUE_TEMPLATE/
+    guidance for examples — "Design Snapshot" → "Demo To Implement"
+    etc.).
+-->
+
+# [Wave N] <title>
+
+---
+
+## Shared Context
+
+<!--
+One or two paragraphs that are TRUE for every issue in this wave. Source
+material the drafter used (design docs, papers, existing code). The goal
+is that another contributor (human or AI agent) can implement this wave
+without opening the private design docs or asking follow-up questions.
+-->
+
+## Design Snapshot
+
+<!--
+Patterns, conventions, or excerpted API signatures that cross-cut every
+issue in this wave. Copy the signatures here so children don't have to
+duplicate them. Examples of what belongs here:
+
+- Cross-cutting interface or protocol: `class Foo(eqx.Module): ...`
+- A convention every child must respect: natural-parameter state
+  (η, s) not moment (m, v); log-likelihood convention; `_for_loss`
+  wrapper pattern.
+- Shared types: `class WaveState(NamedTuple): ...`
+
+Keep prose short — lead with code.
+-->
+
+```python
+# Lead with the most important cross-cutting signature or pattern.
+```
+
+## Intended Package Layout
+
+<!--
+If this wave introduces new modules, show the intended layout. Later
+waves get to assume this shape. Keep it to the modules touched by
+THIS wave — don't sketch the whole package.
+-->
+
+```text
+src/<package>/
+  __init__.py
+  _core/
+    __init__.py
+    <new_module>.py
+  ...
+```
+
+## Runtime Boundary
+
+<!-- Optional. Dependency boundaries this wave introduces or enforces. -->
+
+- **Required runtime**: `<deps>`
+- **Optional runtime**: `<deps>`
+- **Dev / test only**: `<deps>`
+- **Examples / docs only**: `<deps>`
+
+---
+
+# [Wave N] <wave title>
+Draft ID: `<PREFIX>-01`
+
+## Goal
+<!-- One sentence: what outcome does this wave deliver? Maps to a milestone / release. -->
+
+## Why This Wave Exists
+<!-- Narrative motivation. Explains what the wave unlocks and what's blocked without it. -->
+
+## Canonical Epics
+- [ ] `<PREFIX>-02` [Epic] N.A <theme title>
+- [ ] `<PREFIX>-03` [Epic] N.B <theme title>
+- [ ] `<PREFIX>-04` [Epic] N.C <theme title>
+
+## Sequential Dependencies
+<!-- e.g. A must land before B; C can run in parallel with both. -->
+
+## Definition of Done
+- [ ] All theme epics closed
+- [ ] Milestone released (tag + changelog)
+- [ ] Tests / lint / format / typecheck all pass on `main`
+
+## Relationships
+- Blocks `<PREFIX-of-next-wave>-01`
+- Related: <design-doc references>
+
+---
+
+# [Epic] N.A <theme title>
+Draft ID: `<PREFIX>-02`
+
+## Theme
+<!-- One-sentence theme / outcome for this group. -->
+
+## Parent Wave
+`<PREFIX>-01`
+
+## Motivation
+<!-- Why this group exists; what it ships together. -->
+
+## Canonical Child Issues
+- [ ] `<PREFIX>-05` <feature title>
+- [ ] `<PREFIX>-06` <feature title>
+
+## Execution Notes
+<!--
+Describes ordering / sequencing between child issues. e.g. "PYX-05
+should land first because most path rewrites depend on the final
+package name. PYX-06 can start once the target module layout is
+agreed."
+Optional — delete if children are fully parallel.
+-->
+
+## Definition of Done
+- [ ] All child issues closed
+- [ ] Tests for the theme's surface land and pass
+
+## Relationships
+- Parent wave: `<PREFIX>-01`
+
+---
+
+# [Epic] N.B <theme title>
+Draft ID: `<PREFIX>-03`
+
+## Theme
+## Parent Wave
+`<PREFIX>-01`
+
+## Motivation
+
+## Canonical Child Issues
+- [ ] `<PREFIX>-07` <title>
+
+## Execution Notes
+
+## Definition of Done
+- [ ]
+
+## Relationships
+- Parent wave: `<PREFIX>-01`
+
+---
+
+# <scope>: <feature title>
+Draft ID: `<PREFIX>-05`
+
+## Problem / Request
+<!-- Two sentences max. -->
+
+## User Story
+> As a <role>, I want <capability>, so that <outcome>.
+
+## Proposed API
+```python
+# Signatures, types, docstring stubs. Lead with code, prose second.
+```
+
+## Design Snapshot
+<!--
+Cross-cutting context lives at the top of the wave file — don't
+duplicate it here. Use this section for content specific to THIS
+issue. Rename if warranted ("Demo To Implement", "Config Snippet",
+etc.). Delete if not needed.
+-->
+
+## Mathematical Notes
+<!--
+Issue-specific equations. For algorithmic issues this section should be
+treated as REQUIRED and should carry enough math that another agent can
+implement the issue without reopening the design docs.
+
+Recommended contents:
+- defining equations
+- parameterization / sign conventions
+- approximation / factorization used
+- identities or invariants tests should pin down
+
+Use GitHub math:
+- inline: `$...$`
+- display: `$$...$$`
+
+Delete only if the issue is truly non-algorithmic.
+-->
+
+## Implementation Notes
+<!--
+Prose bullets describing HOW to implement. Use this for issues where
+the checklist-style "Implementation Steps" below is too granular
+(e.g. when implementation shape depends on a design decision that
+resolves during the work).
+-->
+
+- <decision / approach / consideration>
+- <decision / approach / consideration>
+
+## Implementation Steps
+<!-- Concrete, file-level checklist. Each item should be checkable. -->
+- [ ] Add `<symbol>` at `src/<package>/<module>.py`
+- [ ] Export via `src/<package>/__init__.py` (if public)
+
+## Definition of Done
+- [ ] Code lands at the intended path
+- [ ] Tests pass: `make test`
+- [ ] Lint + typecheck pass: `make lint && make typecheck`
+
+## Testing
+- [ ] Unit test: `<what it asserts>`
+- [ ] Property / regression test: `<what it asserts>` (if applicable)
+
+## Documentation
+- [ ] API reference page / section
+- [ ] Notebook or recipe (if user-facing)
+
+## Relationships
+- Parent epic: `<PREFIX>-02`
+- Blocked by: `<PREFIX>-NN>`
+- Blocks: `<PREFIX>-NN>`
+- Related: `<PREFIX>-NN>`
+
+---
+
+# <scope>: <feature title>
+Draft ID: `<PREFIX>-06`
+
+## Problem / Request
+
+## User Story
+
+## Proposed API
+
+## Implementation Notes
+
+## Definition of Done
+- [ ]
+
+## Testing
+
+## Documentation
+
+## Relationships
+- Parent epic: `<PREFIX>-02`
+
+---
+
+# [Design] <design question>
+Draft ID: `<PREFIX>-07`
+
+## Problem / Question
+
+## Proposed Options
+```python
+# Option A
+```
+```python
+# Option B
+```
+
+## Alternatives Considered
+- **Option A** — pros / cons
+- **Option B** — pros / cons
+
+## Decision
+<!-- Filled in when resolved. -->
+
+## Consequences
+
+## Relationships
+- Parent epic: `<PREFIX>-03`
+- Blocks: <list of child issues that can't start until this resolves>
+
+---
+
+## Publishing Checklist
+
+When the draft is ready to become real GitHub issues:
+
+- [ ] For each `Draft ID`, open a GH issue using the matching
+      `.github/ISSUE_TEMPLATE/*.md` template. Copy the body verbatim
+      into the issue.
+- [ ] After opening, record the GH issue number next to the draft ID
+      in this file (`<PREFIX>-05` → `#42`) OR replace the draft IDs
+      with GH numbers throughout.
+- [ ] Update cross-references (`Parent epic`, `Blocked by`, `Blocks`,
+      `Related`) from draft IDs to GH numbers so relationships survive
+      in the GH UI.
+- [ ] **Apply native relationships.** The prose `Parent:` / `Blocked
+      by:` / `Blocks:` lines are the human-readable record; they also
+      need the native GitHub sub-issue and dependency links so the UI
+      and automation pick up the hierarchy.
+      - Sub-issues (wave → themes → features):
+        `make gh-sub PARENT=<parent#> CHILDREN="<child1#> <child2#> ..."`
+      - Blocked-by:
+        `make gh-block ISSUE=<this#> BLOCKED_BY=<other#>`
+      - For bulk application, see `.github/scripts/link-issues.sh` or
+        the `link-gh-issues` Claude Code skill.
+- [ ] Either delete this file or keep it as historical record in
+      `.plans/archive/`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ plugins:
 nav:
   - Home: index.md
   - API Reference: api/reference.md
+  - Contributing: contributing.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

Brings `gauss_flows` up to parity with the shared `pypackage_template` scaffolding. Pure additions — no source code or existing config touched.

### Added
- **Top-level docs**: `CONTRIBUTING.md`, `CODE_REVIEW.md`
- **`docs/contributing.md`**: full label taxonomy + epic model writeup; wired into `mkdocs.yml` nav
- **`.github/ISSUE_TEMPLATE/`**: bug, feature, design, research, epic-theme, epic-wave, config
- **`.github/scripts/`**: `create-labels.sh` (bootstrap label taxonomy) and `link-issues.sh` (native sub-issues + blocked-by via GraphQL)
- **`.github/skills/code-review/SKILL.md`**: pointer skill referencing `/CODE_REVIEW.md`
- **Makefile**: `gh-labels`, `gh-sub`, `gh-block`, `gh-show` targets that wrap the new scripts

### Intentionally left alone (drift to resolve manually)
These files differ between the template and gauss_flows but appear to have repo-specific customisations — overwriting blindly would clobber them:
- `.github/labeler.yml`
- `.github/copilot-instructions.md`
- `.github/instructions/{docs-examples,python-coding}.instructions.md`
- `.github/workflows/{release-please,typecheck}.yml`

## Test plan
- [ ] `make help` shows the new GitHub section
- [ ] `mkdocs build` succeeds with the new contributing page
- [ ] `bash .github/scripts/create-labels.sh --help` (or just inspect) parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)