### PR TITLE
feat: vae stochastic transform (supersedes #57)

### DIFF
--- a/src/gauss_flows/__init__.py
+++ b/src/gauss_flows/__init__.py
@@ -21,6 +21,7 @@ from gauss_flows._src.numpyro_compat import FlowDist
 from gauss_flows._src.numpyro_guide import FlowGuide
 from gauss_flows._src.train import fit_gaussianization_flow
 from gauss_flows._src.transforms import (
+    VAE,
     ActNorm,
     ActNorm1D,
     AffineCoupling,
@@ -56,6 +57,7 @@ from gauss_flows._src.transforms.base import AbstractStochastic, AbstractSurject
 
 
 __all__ = [
+    "VAE",
     "AbstractStochastic",
     "AbstractSurjection",
     "ActNorm",

--- a/src/gauss_flows/_src/transforms/__init__.py
+++ b/src/gauss_flows/_src/transforms/__init__.py
@@ -36,7 +36,7 @@ from gauss_flows._src.transforms.rotation import (
     LULinearPermute,
     OrthogonalRotation,
 )
-from gauss_flows._src.transforms.stochastic import StochasticPermutation
+from gauss_flows._src.transforms.stochastic import VAE, StochasticPermutation
 from gauss_flows._src.transforms.surjections import (
     Augment,
     SimpleAbsSurjection,
@@ -47,6 +47,7 @@ from gauss_flows._src.transforms.surjections import (
 
 
 __all__ = [
+    "VAE",
     "ActNorm",
     "ActNorm1D",
     "AffineCoupling",

--- a/src/gauss_flows/_src/transforms/stochastic.py
+++ b/src/gauss_flows/_src/transforms/stochastic.py
@@ -19,7 +19,116 @@ import jax.random as jr
 from jax import Array
 from jaxtyping import ArrayLike, PRNGKeyArray
 
+from gauss_flows._src._protocols import ConditionalDistribution
 from gauss_flows._src.transforms.base import AbstractStochastic
+
+
+class VAE(AbstractStochastic):
+    r"""Variational autoencoder as a SurVAE stochastic transform.
+
+    Wraps an encoder ``q(z | x)`` and decoder ``p(x | z)`` so that a VAE
+    becomes a single link in a :class:`SurVAEFlow` chain. Stacking ``N`` of
+    these yields an ``N``-level HVAE with no bespoke container code — the
+    chain machinery already handles key splitting and ELBO accumulation.
+
+    Forward (data → latent, used inside ``log_prob``)::
+
+        z ~ q(z | x)
+        log_det = log p(x | z) − log q(z | x)
+
+    The forward ``log_det`` is exactly the per-event ELBO contribution of a
+    single stochastic lift (Nielsen et al. 2020, eq. 7): together with the
+    base-distribution term ``log p(z)`` it yields the standard ELBO
+    ``E_q[log p(x|z) + log p(z) − log q(z|x)]``.
+
+    Inverse (latent → data, used for generation)::
+
+        x ~ p(x | z)
+        log_det = 0   (inverse is not consumed by ``log_prob``)
+
+    Args:
+        encoder: Conditional distribution ``q(z | x)``. Must expose
+            ``sample(key, *, condition)`` and
+            ``log_prob(value, *, condition)`` — the
+            :class:`ConditionalDistribution` protocol. **``sample`` must
+            be reparameterized** (e.g. location–scale Gaussian with
+            ``mean + scale * eps``); otherwise gradients through the ELBO
+            are biased.
+        decoder: Conditional distribution ``p(x | z)`` with the same
+            protocol. Reparameterization is **not** required for the
+            decoder — its ``log_prob`` is the only thing differentiated.
+
+    Shape:
+        - Input ``x``: ``encoder`` condition shape
+        - Output ``z``: ``encoder`` sample shape
+        - ``log_det``: scalar (shape ``()``)
+
+    Note:
+        Unconditional distributions such as ``flowjax.distributions.Normal``
+        do **not** satisfy the :class:`ConditionalDistribution` protocol
+        (they have no ``condition=`` kwarg). A small wrapper that amortises
+        the parameters on the conditioning variable is required — see the
+        ``DiagGaussianConditional`` helper used in
+        ``tests/test_transforms_stochastic.py`` for a minimal reference.
+
+    Example:
+        Compose with a standard Normal prior to form a one-level VAE flow::
+
+            from gauss_flows import SurVAEFlow, VAE
+            from flowjax.distributions import Normal
+
+            encoder = MyConditionalGaussian(...)   # q(z|x), reparameterized
+            decoder = MyConditionalGaussian(...)   # p(x|z)
+            vae = VAE(encoder, decoder)
+            flow = SurVAEFlow(Normal(jnp.zeros(latent_dim)), [vae])
+
+    References:
+        Nielsen, Jaini, Hoogeboom, Winther, Welling.
+        *SurVAE Flows: Surjections to Bridge the Gap between VAEs and
+        Flows*, NeurIPS 2020.
+    """
+
+    encoder: ConditionalDistribution
+    decoder: ConditionalDistribution
+    cond_shape: ClassVar[None] = None
+
+    def __init__(
+        self,
+        encoder: ConditionalDistribution,
+        decoder: ConditionalDistribution,
+    ):
+        self.encoder = encoder
+        self.decoder = decoder
+
+    def forward_and_log_det(
+        self,
+        x: ArrayLike,
+        key: PRNGKeyArray,
+        cond: Array | None = None,
+    ) -> tuple[Array, Array]:
+        r"""Sample ``z ~ q(z | x)`` and return ``log p(x | z) − log q(z | x)``.
+
+        Uses a single reparameterized sample for both the returned ``z`` and
+        the ELBO estimate — the caller's vmap over a batch axis amortizes
+        the Monte Carlo variance.
+        """
+        del cond
+        x_arr = jnp.asarray(x)
+        z = self.encoder.sample(key, condition=x_arr)
+        log_p = self.decoder.log_prob(x_arr, condition=z)
+        log_q = self.encoder.log_prob(z, condition=x_arr)
+        return z, log_p - log_q
+
+    def inverse_and_log_det(
+        self,
+        z: ArrayLike,
+        key: PRNGKeyArray,
+        cond: Array | None = None,
+    ) -> tuple[Array, Array]:
+        """Sample ``x ~ p(x | z)``; inverse log-det is zero by convention."""
+        del cond
+        x = self.decoder.sample(key, condition=jnp.asarray(z))
+        return x, jnp.zeros(())
 
 
 class StochasticPermutation(AbstractStochastic):
@@ -110,4 +219,4 @@ class StochasticPermutation(AbstractStochastic):
         return x, jnp.zeros(())
 
 
-__all__ = ["StochasticPermutation"]
+__all__ = ["VAE", "StochasticPermutation"]

--- a/src/gauss_flows/_src/transforms/stochastic.py
+++ b/src/gauss_flows/_src/transforms/stochastic.py
@@ -74,8 +74,9 @@ class VAE(AbstractStochastic):
     Example:
         Compose with a standard Normal prior to form a one-level VAE flow::
 
-            from gauss_flows import SurVAEFlow, VAE
+            import jax.numpy as jnp
             from flowjax.distributions import Normal
+            from gauss_flows import SurVAEFlow, VAE
 
             encoder = MyConditionalGaussian(...)   # q(z|x), reparameterized
             decoder = MyConditionalGaussian(...)   # p(x|z)

--- a/tests/test_transforms_stochastic.py
+++ b/tests/test_transforms_stochastic.py
@@ -1,0 +1,216 @@
+"""Tests for :class:`VAE` — SurVAE stochastic transform."""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import optax
+import pytest
+from flowjax.distributions import Normal
+from jax import Array
+from jaxtyping import PRNGKeyArray
+
+from gauss_flows import VAE, SurVAEFlow
+
+
+class DiagGaussianConditional(eqx.Module):
+    """Minimal reparameterized conditional Gaussian ``N(Wc+b, softplus(log_s)^2·I)``.
+
+    Matches the :class:`ConditionalDistribution` protocol and is
+    differentiable end-to-end through the reparameterization trick. Used as
+    both encoder and decoder for the VAE tests; small enough to keep the
+    smoke test fast.
+    """
+
+    weight: Array
+    bias: Array
+    log_scale: Array
+
+    def __init__(self, key: PRNGKeyArray, in_dim: int, out_dim: int):
+        w_key, b_key = jr.split(key)
+        self.weight = jr.normal(w_key, (out_dim, in_dim)) * 0.1
+        self.bias = jr.normal(b_key, (out_dim,)) * 0.1
+        self.log_scale = jnp.full((out_dim,), -0.3)
+
+    def _mean(self, condition: Array) -> Array:
+        return self.weight @ condition + self.bias
+
+    def _scale(self) -> Array:
+        return jax.nn.softplus(self.log_scale) + 1e-3
+
+    def sample(self, key: PRNGKeyArray, *, condition: Array) -> Array:
+        mean = self._mean(jnp.asarray(condition))
+        scale = self._scale()
+        eps = jr.normal(key, mean.shape)
+        return mean + scale * eps  # reparameterized
+
+    def log_prob(self, value: Array, *, condition: Array) -> Array:
+        mean = self._mean(jnp.asarray(condition))
+        scale = self._scale()
+        var = scale**2
+        log_norm = -0.5 * jnp.log(2 * jnp.pi * var)
+        quad = -0.5 * ((jnp.asarray(value) - mean) ** 2) / var
+        return jnp.sum(log_norm + quad)
+
+
+def test_vae_forward_returns_encoder_sample_and_elbo_term(key):
+    """Forward must return the sampled z and exactly log p(x|z) - log q(z|x).
+
+    Recomputing the identity from the *same* z is tautological; what matters
+    is that the class returns z from `encoder.sample` and the ELBO term
+    evaluated at that same z, which this test pins down.
+    """
+    encoder = DiagGaussianConditional(jr.fold_in(key, 0), in_dim=2, out_dim=2)
+    decoder = DiagGaussianConditional(jr.fold_in(key, 1), in_dim=2, out_dim=2)
+    vae = VAE(encoder, decoder)
+    x = jnp.array([0.3, -0.7])
+
+    fwd_key = jr.fold_in(key, 2)
+    z, log_det = vae.forward_and_log_det(x, fwd_key)
+    z_expected = encoder.sample(fwd_key, condition=x)
+    expected = decoder.log_prob(x, condition=z_expected) - encoder.log_prob(
+        z_expected, condition=x
+    )
+
+    assert z.shape == x.shape
+    assert jnp.allclose(z, z_expected)
+    assert jnp.allclose(log_det, expected)
+
+
+def test_vae_forward_elbo_matches_closed_form_gaussian_kl(key):
+    """Monte-Carlo ``E[log p(x|z) - log q(z|x)]`` must match the closed-form
+    ``log p(x|μ_q) - 0.5·tr(Σ_q/σ_p²) - H(q)`` for Gaussian q/p.
+
+    Concretely, with ``q(z|x) = N(μ_q, diag(s_q²))``,
+    ``p(x|z) = N(Wz+b, diag(s_p²))``, the expectation decomposes as::
+
+        E[log p(x|z)]  = log N(x; Wμ_q+b, diag(s_p²)) − 0.5·tr(W diag(s_q²) Wᵀ / s_p²)
+        E[log q(z|x)] = -H(q) = -0.5·Σ(log(2πe s_q²))
+
+    With enough samples the MC estimate lands within 3σ of this value,
+    verifying both the sampling and the log-prob paths are wired correctly.
+    """
+    enc_key, dec_key, sample_key = jr.split(key, 3)
+    in_dim, out_dim = 2, 2
+    encoder = DiagGaussianConditional(enc_key, in_dim=in_dim, out_dim=out_dim)
+    decoder = DiagGaussianConditional(dec_key, in_dim=out_dim, out_dim=in_dim)
+    vae = VAE(encoder, decoder)
+    x = jnp.array([0.5, -0.2])
+
+    n_samples = 4096
+    keys = jr.split(sample_key, n_samples)
+    # one forward per key; take the log_det only.
+    _, log_dets = jax.vmap(lambda k: vae.forward_and_log_det(x, k))(keys)
+    mc_estimate = jnp.mean(log_dets)
+
+    # Closed form for Gaussian q, p.
+    mu_q = encoder._mean(x)
+    s_q = encoder._scale()
+    mu_p = decoder._mean(mu_q)  # E_q[Wz+b] = W μ_q + b
+    s_p = decoder._scale()
+    var_p = s_p**2
+    # E[log p(x|z)] under q:
+    log_p_at_mean = jnp.sum(
+        -0.5 * jnp.log(2 * jnp.pi * var_p) - 0.5 * (x - mu_p) ** 2 / var_p
+    )
+    trace_term = 0.5 * jnp.sum(
+        (decoder.weight @ (s_q**2 * decoder.weight.T)).diagonal() / var_p
+    )
+    expected_log_p = log_p_at_mean - trace_term
+    # Entropy of q: H(q) = 0.5 Σ log(2π e s_q²)
+    entropy_q = 0.5 * jnp.sum(jnp.log(2 * jnp.pi * jnp.e * s_q**2))
+    # E[log q(z|x)] = -H(q)
+    expected_log_q = -entropy_q
+    closed_form = expected_log_p - expected_log_q
+
+    # 3-sigma MC tolerance on 4096 samples is ~ O(0.05) for this problem.
+    assert jnp.allclose(mc_estimate, closed_form, atol=0.1)
+
+
+def test_vae_inverse_samples_and_zero_log_det(key):
+    encoder = DiagGaussianConditional(jr.fold_in(key, 0), in_dim=2, out_dim=2)
+    decoder = DiagGaussianConditional(jr.fold_in(key, 1), in_dim=2, out_dim=2)
+    vae = VAE(encoder, decoder)
+    z = jnp.array([1.0, -1.0])
+    x, log_det = vae.inverse_and_log_det(z, jr.fold_in(key, 3))
+    assert x.shape == z.shape
+    assert log_det == pytest.approx(0.0)
+
+
+def test_vae_inverse_matches_decoder_sample(key):
+    """Inverse must delegate to ``decoder.sample`` with the same key."""
+    encoder = DiagGaussianConditional(jr.fold_in(key, 0), in_dim=2, out_dim=2)
+    decoder = DiagGaussianConditional(jr.fold_in(key, 1), in_dim=2, out_dim=2)
+    vae = VAE(encoder, decoder)
+    z = jnp.array([0.25, 0.75])
+    inv_key = jr.fold_in(key, 4)
+    x, _ = vae.inverse_and_log_det(z, inv_key)
+    expected = decoder.sample(inv_key, condition=z)
+    assert jnp.allclose(x, expected)
+
+
+def test_vae_cond_shape_is_none(key):
+    """``VAE`` is unconditional at the chain level — matches every other
+    unconditional transform in the package."""
+    encoder = DiagGaussianConditional(jr.fold_in(key, 0), in_dim=2, out_dim=2)
+    decoder = DiagGaussianConditional(jr.fold_in(key, 1), in_dim=2, out_dim=2)
+    vae = VAE(encoder, decoder)
+    assert vae.cond_shape is None
+
+
+@pytest.mark.slow
+def test_vae_svi_smoke_trains_below_fixed_prior_baseline(key):
+    """SVI sanity check: trained VAE ELBO should beat the *fixed* prior baseline.
+
+    Key correctness points:
+      - The ``Normal`` base_dist has trainable parameters in flowjax, so we
+        compute the baseline *before* training against the original fixed
+        prior, not against the drifted post-training prior.
+      - The training step is wrapped in ``eqx.filter_jit`` so 500 iterations
+        are not 500 Python-level retraces.
+      - We compare the mean of the last segment to the first, rather than
+        requiring strictly monotone segment means (which is flaky under
+        Adam with ``n=256`` batches).
+    """
+    latent_dim = 2
+    data = jr.normal(jr.fold_in(key, 10), (256, latent_dim)) + jnp.array([1.0, -1.0])
+
+    encoder = DiagGaussianConditional(
+        jr.fold_in(key, 20), in_dim=latent_dim, out_dim=latent_dim
+    )
+    decoder = DiagGaussianConditional(
+        jr.fold_in(key, 30), in_dim=latent_dim, out_dim=latent_dim
+    )
+    flow = SurVAEFlow(Normal(jnp.zeros(latent_dim)), [VAE(encoder, decoder)])
+
+    # Baseline from the fixed standard-normal prior, BEFORE any updates.
+    fixed_prior = Normal(jnp.zeros(latent_dim))
+    baseline = -jnp.mean(jax.vmap(fixed_prior.log_prob)(data))
+
+    def loss_fn(model, k):
+        return -jnp.mean(model.log_prob(data, k))
+
+    optim = optax.adam(1e-3)
+    opt_state = optim.init(eqx.filter(flow, eqx.is_inexact_array))
+
+    @eqx.filter_jit
+    def step(model, opt_state, k):
+        loss, grads = eqx.filter_value_and_grad(loss_fn)(model, k)
+        updates, opt_state = optim.update(grads, opt_state)
+        return eqx.apply_updates(model, updates), opt_state, loss
+
+    train_keys = jr.split(jr.fold_in(key, 999), 500)
+    losses = []
+    for step_key in train_keys:
+        flow, opt_state, loss = step(flow, opt_state, step_key)
+        losses.append(loss)
+    losses = jnp.stack(losses)
+
+    assert jnp.isfinite(losses).all()
+    # Trained VAE should beat the fixed-prior baseline.
+    assert losses[-1] < baseline
+    # Compare mean of the last segment to the first — robust to Adam noise.
+    segment_means = losses.reshape(5, 100).mean(axis=1)
+    assert segment_means[-1] < segment_means[0] - 1e-2

--- a/tests/test_transforms_stochastic.py
+++ b/tests/test_transforms_stochastic.py
@@ -81,15 +81,17 @@ def test_vae_forward_returns_encoder_sample_and_elbo_term(key):
 
 def test_vae_forward_elbo_matches_closed_form_gaussian_kl(key):
     """Monte-Carlo ``E[log p(x|z) - log q(z|x)]`` must match the closed-form
-    ``log p(x|μ_q) - 0.5·tr(Σ_q/σ_p²) - H(q)`` for Gaussian q/p.
+    ``log p(x|Wμ_q+b, Σ_p) - 0.5·tr(W Σ_q Wᵀ Σ_p⁻¹) + H(q)`` for Gaussian q/p.
 
     Concretely, with ``q(z|x) = N(μ_q, diag(s_q²))``,
     ``p(x|z) = N(Wz+b, diag(s_p²))``, the expectation decomposes as::
 
-        E[log p(x|z)]  = log N(x; Wμ_q+b, diag(s_p²)) − 0.5·tr(W diag(s_q²) Wᵀ / s_p²)
-        E[log q(z|x)] = -H(q) = -0.5·Σ(log(2πe s_q²))
+        E[log p(x|z)]   = log N(x; Wμ_q+b, diag(s_p²)) − 0.5·tr(W diag(s_q²) Wᵀ / s_p²)
+        E[log q(z|x)]  = -H(q) = -0.5·Σ log(2πe s_q²)
 
-    With enough samples the MC estimate lands within 3σ of this value,
+        E[log p(x|z) - log q(z|x)] = E[log p(x|z)] + H(q)
+
+    With enough samples the MC estimate lands within 3-sigma of this value,
     verifying both the sampling and the log-prob paths are wired correctly.
     """
     enc_key, dec_key, sample_key = jr.split(key, 3)


### PR DESCRIPTION
Supersedes #57. Addresses the two Copilot P2 concerns and the issues raised in review of that PR.

## What changed vs #57

| Concern | Fix |
|---|---|
| Docstring example passed unconditional `flowjax.Normal` where a `ConditionalDistribution` is required — would `TypeError` at runtime. | Replaced with a narrative example that points users at the `DiagGaussianConditional` helper in the test suite for a concrete conditional wrapper. |
| Missing `cond_shape: ClassVar[None] = None`. | Added. Matches every other unconditional transform in the package. |
| Reparameterization requirement on `encoder.sample` was unstated. Users passing a non-reparameterized distribution would get biased ELBO gradients silently. | Documented explicitly in the class docstring, under **Args → encoder**. |
| SVI smoke-test baseline computed *after* training, using `flow.base_dist` whose `loc` drifted under `eqx.filter(..., is_inexact_array)`. | Baseline is now captured from the original fixed `Normal(jnp.zeros(latent_dim))` **before** any updates. |
| 500-step Python training loop not wrapped in `jit`, not marked slow. | Step body wrapped in `eqx.filter_jit` (single trace) and marked `@pytest.mark.slow` so `make test-fast` skips it. |
| Strict monotone-decrease assertion on segment means — flaky under Adam noise. | Softened to `segment_means[-1] < segment_means[0] - 1e-2`, which captures "training improves" without requiring monotone segments. |
| Forward-sum test was tautological: it recomputed `log p(x\|z) - log q(z\|x)` from the same `z` the class had already used. | Replaced with a genuine Monte-Carlo vs closed-form Gaussian identity check (4096 samples agree with analytic ELBO within 1e-1). |
| `__all__` ordering placed `VAE` out of sorted position in both `__init__.py` files. | Auto-sorted by `ruff --fix`. |

## Math summary

Forward (data → latent, inside `log_prob`):

$$
z \sim q(z \mid x), \qquad
\log\det = \log p(x \mid z) - \log q(z \mid x)
$$

Inverse (latent → data, used for generation only):

$$
x \sim p(x \mid z), \qquad \log\det = 0
$$

With base prior $p(z)$ the total `log_prob` contribution is
$\mathbb{E}_q[\log p(x\mid z) + \log p(z) - \log q(z\mid x)]$ — the standard ELBO.

## Test plan

- [x] `test_vae_forward_returns_encoder_sample_and_elbo_term` — return pins z and log_det
- [x] `test_vae_forward_elbo_matches_closed_form_gaussian_kl` — 4096-sample MC estimate within 1e-1 of analytic Gaussian ELBO
- [x] `test_vae_inverse_samples_and_zero_log_det`
- [x] `test_vae_inverse_matches_decoder_sample` — inverse delegates to `decoder.sample` with caller's key
- [x] `test_vae_cond_shape_is_none`
- [x] `test_vae_svi_smoke_trains_below_fixed_prior_baseline` (`@slow`) — fixed-prior baseline, `filter_jit` step, softened convergence check
- [x] `ruff format --check`, `ruff check .`, `ty check src/gauss_flows` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)