### PR TITLE
feat: make interpax an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,16 +27,17 @@ dependencies = [
     "flowjax>=0.9",
     "equinox>=0.10",
     "numpyro>=0.13",
-    "optax>=0.1",
     "paramax",
     "jaxtyping",
     "einops>=0.8.2",
     "optimistix>=0.0.9",
-    "interpax>=0.3.13",
     "scikit-learn>=1.3",
     "diffrax>=0.7.2,<0.8",
     "matfree>=0.5.5,<0.6",
 ]
+
+[project.optional-dependencies]
+interp = ["interpax>=0.3.13"]
 
 [project.urls]
 Repository = "https://github.com/jejjohnson/gauss_flows"
@@ -48,6 +49,8 @@ dev = [
     "pytest-xdist>=3.5.0",
     "pre-commit>=4.5.1",
     "scipy>=1.13",
+    "optax>=0.1",
+    "interpax>=0.3.13",
 ]
 lint = [
     "ruff>=0.15.10",

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
@@ -11,6 +11,7 @@ from flowjax.bijections import AbstractBijection
 from jax import Array
 from jaxtyping import ArrayLike
 
+
 if TYPE_CHECKING:
     import interpax
 

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import equinox as eqx
-import interpax
 import jax
 import jax.numpy as jnp
 from flowjax.bijections import AbstractBijection
 from jax import Array
 from jaxtyping import ArrayLike
+
+if TYPE_CHECKING:
+    import interpax
 
 
 class HistogramCDF(AbstractBijection):
@@ -119,7 +121,18 @@ class HistogramCDF(AbstractBijection):
             ``bin_pdf``, ``cdf_edges``, and per-dim forward/inverse
             interpolators populated. Idempotent: refitting with the same
             data yields the same fitted parameters.
+
+        Raises:
+            ImportError: If ``interpax`` is not installed. Install it with
+                ``pip install gauss-flows[interp]``.
         """
+        try:
+            import interpax
+        except ImportError as e:
+            raise ImportError(
+                "HistogramCDF.fit() requires interpax. "
+                "Install it with: pip install gauss-flows[interp]"
+            ) from e
         # values: (n_samples, n_dims)
         values = jnp.asarray(data)
         if values.ndim != 2 or values.shape[1] != self.shape[0]:

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
@@ -129,8 +129,8 @@ class HistogramCDF(AbstractBijection):
         """
         try:
             import interpax
-        except ImportError as e:
-            raise ImportError(
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
                 "HistogramCDF.fit() requires interpax. "
                 "Install it with: pip install gauss-flows[interp]"
             ) from e

--- a/uv.lock
+++ b/uv.lock
@@ -496,27 +496,32 @@ wheels = [
 
 [[package]]
 name = "gauss-flows"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "diffrax" },
     { name = "einops" },
     { name = "equinox" },
     { name = "flowjax" },
-    { name = "interpax" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxtyping" },
     { name = "matfree" },
     { name = "numpyro" },
-    { name = "optax" },
     { name = "optimistix" },
     { name = "paramax" },
     { name = "scikit-learn" },
 ]
 
+[package.optional-dependencies]
+interp = [
+    { name = "interpax" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "interpax" },
+    { name = "optax" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -542,24 +547,26 @@ typecheck = [
 
 [package.metadata]
 requires-dist = [
-    { name = "diffrax", specifier = "==0.7.2" },
+    { name = "diffrax", specifier = ">=0.7.2,<0.8" },
     { name = "einops", specifier = ">=0.8.2" },
     { name = "equinox", specifier = ">=0.10" },
     { name = "flowjax", specifier = ">=0.9" },
-    { name = "interpax", specifier = ">=0.3.13" },
+    { name = "interpax", marker = "extra == 'interp'", specifier = ">=0.3.13" },
     { name = "jax", specifier = ">=0.4.30" },
     { name = "jaxlib", specifier = ">=0.4.30" },
     { name = "jaxtyping" },
-    { name = "matfree", specifier = "==0.5.5" },
+    { name = "matfree", specifier = ">=0.5.5,<0.6" },
     { name = "numpyro", specifier = ">=0.13" },
-    { name = "optax", specifier = ">=0.1" },
     { name = "optimistix", specifier = ">=0.0.9" },
     { name = "paramax" },
     { name = "scikit-learn", specifier = ">=1.3" },
 ]
+provides-extras = ["interp"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "interpax", specifier = ">=0.3.13" },
+    { name = "optax", specifier = ">=0.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },


### PR DESCRIPTION
## Summary

- `interpax` is only used in `HistogramCDF.fit()` but was a hard dependency, forcing a `lineax<=0.1.0` upper bound on all users. This conflicts with `pyrox` and `gaussx` which both require `lineax>=0.1.1`.
- `optax` was a hard dependency but is only used in tests (flowjax pulls it in transitively anyway).

## Changes

- Move `interpax` to `[project.optional-dependencies]` under the `interp` extra (`pip install gauss-flows[interp]`)
- Lazy-import `interpax` inside `HistogramCDF.fit()` with a clear `ImportError` pointing to the extra
- Guard the `interpax.Interpolator1D` type annotation with `TYPE_CHECKING` (already safe due to `from __future__ import annotations`)
- Move `optax` from core deps to dev group
- Add both `interpax` and `optax` to dev deps so the existing test suite runs unchanged

## Test plan

- [ ] `pytest tests/test_transforms_marginal.py` still passes (interpax is in dev deps)
- [ ] `pip install gauss-flows` (without `[interp]`) installs without pulling in interpax
- [ ] `HistogramCDF.fit()` raises a clear `ImportError` when interpax is absent
- [ ] `pip install gauss-flows[interp]` installs interpax and `HistogramCDF` works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)