### PR TITLE
feat(tests): add slow/integration markers, skip slow in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
       - name: Run tests with coverage
-        run: uv run pytest -v
+        run: uv run pytest -v -m "not slow"
+      - name: Run slow tests (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: uv run pytest -v -m "slow" --no-cov
       - name: Upload coverage report
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,8 @@ unresolved-attribute = "ignore"
 testpaths = ["tests"]
 addopts = "-ra --strict-markers --tb=short --cov=src/gauss_flows --cov-report=term-missing --cov-report=xml:coverage.xml"
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "slow: marks tests as slow — training loops, large-sample convergence checks (deselect with '-m \"not slow\"')",
+    "integration: marks end-to-end integration tests — build model → fit → evaluate",
 ]
 
 [tool.coverage.run]

--- a/tests/test_continuous_affine_coupling.py
+++ b/tests/test_continuous_affine_coupling.py
@@ -277,6 +277,8 @@ def test_continuous_affine_coupling_vmap_matches_loop(key):
     assert jnp.allclose(batched_log_det, jnp.stack(loop_log_det), atol=1e-6)
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_continuous_affine_coupling_training_sanity(key):
     n_samples = 64
     t = jnp.linspace(0.1, 1.0, n_samples)

--- a/tests/test_distributions_mixture.py
+++ b/tests/test_distributions_mixture.py
@@ -80,6 +80,8 @@ def test_weights_respected(key):
     assert fraction_near_c0 > 0.95
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_fits_known_gmm_via_log_prob_improvement(key):
     """Crude fit test: after a few steps of max-likelihood the model should
     assign strictly higher average log-prob than a poorly-initialised one.
@@ -128,6 +130,7 @@ def test_fits_known_gmm_via_log_prob_improvement(key):
     assert mean_lp_fit > mean_lp_init + 0.1
 
 
+@pytest.mark.integration
 def test_as_base_dist_in_gaussianization_flow(key):
     k_base, k_flow, k_sample = jr.split(key, 3)
     base = GaussianMixture(k_base, n_components=3, event_shape=(3,))

--- a/tests/test_distributions_pca.py
+++ b/tests/test_distributions_pca.py
@@ -38,6 +38,7 @@ def test_sample_shape_and_finite(key):
     assert jnp.all(jnp.isfinite(samples))
 
 
+@pytest.mark.slow
 def test_sample_moments_match_covariance(key):
     """Empirical mean/cov from 20k samples match loc and W W^T + sigma^2 I."""
     d, k = 5, 2
@@ -50,6 +51,7 @@ def test_sample_moments_match_covariance(key):
     assert jnp.allclose(empirical_cov, dist.covariance(), atol=0.1)
 
 
+@pytest.mark.integration
 def test_as_base_dist_in_gaussianization_flow(key):
     k_base, k_flow, k_sample = jr.split(key, 3)
     base = GaussianPCA(k_base, event_shape=(4,), latent_dim=2)

--- a/tests/test_distributions_sphere.py
+++ b/tests/test_distributions_sphere.py
@@ -41,6 +41,7 @@ def test_uniform_on_sphere_log_prob_matches_surface_area(key, d):
 
 
 @pytest.mark.parametrize("d", [1, 2, 3, 7])
+@pytest.mark.slow
 def test_uniform_on_sphere_sample_mean_near_zero(key, d):
     dist = UniformOnSphere(d)
     samples = dist.sample(jr.fold_in(key, 100 + d), sample_shape=(20_000,))
@@ -73,6 +74,7 @@ def test_von_mises_fisher_log_prob_matches_scipy(key, d, concentration):
 
 
 @pytest.mark.parametrize("d, concentration", [(1, 1.0), (2, 5.0), (7, 10.0)])
+@pytest.mark.slow
 def test_von_mises_fisher_sample_mean_matches_theory(key, d, concentration):
     mean = _normalize(jr.normal(jr.fold_in(key, d), (d + 1,)))
     dist = VonMisesFisher(mean, concentration)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2,6 +2,7 @@
 
 import jax.numpy as jnp
 import jax.random as jr
+import pytest
 
 import gauss_flows
 
@@ -11,6 +12,7 @@ def test_gaussianization_flow_creates_distribution(key):
     assert flow.shape == (2,)
 
 
+@pytest.mark.integration
 def test_gaussianization_flow_log_prob(key, data_2d):
     flow = gauss_flows.gaussianization_flow(key, n_dims=2, n_layers=2, n_components=4)
     log_probs = flow.log_prob(data_2d)
@@ -18,6 +20,7 @@ def test_gaussianization_flow_log_prob(key, data_2d):
     assert jnp.all(jnp.isfinite(log_probs))
 
 
+@pytest.mark.integration
 def test_gaussianization_flow_sample(key):
     flow = gauss_flows.gaussianization_flow(key, n_dims=2, n_layers=2, n_components=4)
     samples = flow.sample(key, (10,))
@@ -32,6 +35,7 @@ def test_coupling_gaussianization_flow_creates_distribution(key):
     assert flow.shape == (4,)
 
 
+@pytest.mark.integration
 def test_coupling_gaussianization_flow_log_prob(key, data_4d):
     flow = gauss_flows.coupling_gaussianization_flow(
         key, n_dims=4, n_layers=2, n_bins=4
@@ -46,12 +50,14 @@ def test_iterative_rbig_creates_distribution(key):
     assert flow.shape == (2,)
 
 
+@pytest.mark.integration
 def test_iterative_rbig_log_prob(key, data_2d):
     flow = gauss_flows.iterative_rbig(key, n_dims=2, n_layers=2, n_components=4)
     log_probs = flow.log_prob(data_2d)
     assert log_probs.shape == (100,)
 
 
+@pytest.mark.integration
 def test_gaussianization_flow_orthogonal_rotation(key):
     flow = gauss_flows.gaussianization_flow(
         key, n_dims=2, n_layers=2, n_components=4, rotation="orthogonal"

--- a/tests/test_flows_survae_conditional.py
+++ b/tests/test_flows_survae_conditional.py
@@ -96,6 +96,7 @@ def _make_numpyro_factory_base(key):
         pytest.param(_make_both, id="both"),
     ],
 )
+@pytest.mark.integration
 def test_survae_conditional_three_configurations(key, make_flow):
     """{base only, coupling only, both} all produce finite log-probs + samples."""
     flow = make_flow(key)
@@ -120,6 +121,7 @@ def test_survae_conditional_three_configurations(key, make_flow):
         pytest.param(_make_both, id="both"),
     ],
 )
+@pytest.mark.integration
 def test_grad_flows_through_conditional_chain(key, make_flow):
     flow = make_flow(key)
     cond = jr.normal(jr.fold_in(key, 100), COND_SHAPE)
@@ -144,6 +146,7 @@ def test_grad_flows_through_conditional_chain(key, make_flow):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_classcond_base_inside_survae(key):
     flow = _make_classcond_base(key)
     label = jnp.int32(2)
@@ -154,6 +157,7 @@ def test_classcond_base_inside_survae(key):
     assert jnp.isfinite(log_p)
 
 
+@pytest.mark.integration
 def test_numpyro_base_inside_survae(key):
     flow = _make_numpyro_factory_base(key)
     cond = jr.normal(jr.fold_in(key, 100), COND_SHAPE)
@@ -169,6 +173,7 @@ def test_numpyro_base_inside_survae(key):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_conditioner_in_mixed_conditional_chain(key):
     """A Conditioner-wrapped rotation composes cleanly with a conditional coupling."""
     rot = OrthogonalRotation(shape=EVENT_SHAPE)
@@ -196,6 +201,7 @@ def test_conditioner_in_mixed_conditional_chain(key):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_four_layer_conditional_affine_stack_in_survae(key):
     from flowjax.bijections import Permute
 

--- a/tests/test_init_rbig.py
+++ b/tests/test_init_rbig.py
@@ -18,6 +18,7 @@ def _skewed_bimodal_2d(key, n: int = 500):
 
 
 class TestFitRbig:
+    @pytest.mark.integration
     def test_output_is_transformed(self, key):
         x = jr.normal(key, (200, 3))
         flow = fit_rbig(x, n_layers=2, n_components=4)
@@ -25,6 +26,7 @@ class TestFitRbig:
         assert hasattr(flow, "log_prob")
         assert hasattr(flow, "sample")
 
+    @pytest.mark.integration
     def test_log_prob_finite(self, key):
         x = jr.normal(key, (200, 3))
         flow = fit_rbig(x, n_layers=3, n_components=4)
@@ -32,6 +34,8 @@ class TestFitRbig:
         assert lp.shape == (200,)
         assert jnp.all(jnp.isfinite(lp))
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_pushforward_is_standard_normal(self, key):
         x = _skewed_bimodal_2d(key, n=800)
         flow = fit_rbig(x, n_layers=6, n_components=6)
@@ -43,6 +47,8 @@ class TestFitRbig:
         assert np.all(np.abs(z.mean(axis=0)) < 0.2)
         assert np.all(np.abs(z.std(axis=0) - 1.0) < 0.2)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_beats_identity_baseline(self, key):
         x = _skewed_bimodal_2d(key, n=500)
         flow = fit_rbig(x, n_layers=4, n_components=4)
@@ -59,6 +65,7 @@ class TestFitRbig:
         with pytest.raises(ValueError, match="must be 2-D"):
             fit_rbig(jnp.zeros((3,)))
 
+    @pytest.mark.integration
     def test_reproducible_via_random_state(self, key):
         x = jr.normal(key, (200, 2))
         flow_a = fit_rbig(x, n_layers=2, n_components=4, random_state=7)
@@ -67,6 +74,8 @@ class TestFitRbig:
         lp_b = flow_b.log_prob(x[:32])
         assert jnp.allclose(lp_a, lp_b)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_narrow_sigmas_preserved_in_init(self, key):
         """Components with fitted sigma in (5e-3, 1e-2) must end up with an
         effective scale close to the fit, not widened to >= 1e-2 by the
@@ -101,12 +110,14 @@ class TestFitRbig:
 
 
 class TestFitRbigCoupling:
+    @pytest.mark.integration
     def test_output_is_transformed(self, key, key2):
         x = jr.normal(key, (200, 4))
         flow = fit_rbig_coupling(x, key2, n_layers=2, n_components=4)
         assert hasattr(flow, "log_prob")
         assert hasattr(flow, "sample")
 
+    @pytest.mark.integration
     def test_log_prob_finite(self, key, key2):
         x = jr.normal(key, (200, 4))
         flow = fit_rbig_coupling(x, key2, n_layers=2, n_components=4)
@@ -114,6 +125,8 @@ class TestFitRbigCoupling:
         assert lp.shape == (200,)
         assert jnp.all(jnp.isfinite(lp))
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_beats_identity_baseline(self, key, key2):
         # Skewed 4D data.
         z = jr.normal(key, (500, 4))
@@ -143,6 +156,8 @@ class TestFitRbigCoupling:
         with pytest.raises(ValueError, match="even n_dims"):
             fit_rbig_coupling(jnp.zeros((10, n_dims)), key2)
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_survives_gradient_training(self, key, key2):
         """Gradient training on a fit_rbig_coupling flow must leave it a true
         bijection — sampling must round-trip to within float32 epsilon.

--- a/tests/test_numpyro.py
+++ b/tests/test_numpyro.py
@@ -1,6 +1,7 @@
 """Tests for NumPyro compatibility."""
 
 import jax.numpy as jnp
+import pytest
 
 import gauss_flows
 
@@ -19,6 +20,7 @@ def test_flowdist_sample(key):
     assert jnp.all(jnp.isfinite(samples))
 
 
+@pytest.mark.integration
 def test_flowdist_log_prob(key, data_2d):
     flow = gauss_flows.gaussianization_flow(key, n_dims=2, n_layers=2, n_components=4)
     flow_dist = gauss_flows.FlowDist(flow)

--- a/tests/test_numpyro_guide.py
+++ b/tests/test_numpyro_guide.py
@@ -3,6 +3,7 @@
 import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
+import pytest
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.optim import Adam
 
@@ -77,6 +78,8 @@ def test_flow_guide_custom_factory():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_flow_guide_svi_runs(key):
     """SVI with FlowGuide completes without error (smoke test)."""
     obs = jnp.array([1.0])
@@ -87,6 +90,8 @@ def test_flow_guide_svi_runs(key):
     assert jnp.all(jnp.isfinite(result.losses))
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_flow_guide_svi_multidim(key):
     """SVI with FlowGuide works for a multi-dimensional latent space."""
     obs = jnp.zeros(3)
@@ -99,6 +104,8 @@ def test_flow_guide_svi_multidim(key):
     assert jnp.all(jnp.isfinite(result.losses))
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_flow_guide_svi_two_sites(key):
     """SVI with FlowGuide works when the model has two latent sites."""
     obs = jnp.array([1.0])
@@ -109,6 +116,8 @@ def test_flow_guide_svi_two_sites(key):
     assert jnp.all(jnp.isfinite(result.losses))
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_flow_guide_svi_coupling_factory(key):
     """SVI with FlowGuide works when coupling_gaussianization_flow is used."""
     obs = jnp.array([1.0])
@@ -128,6 +137,8 @@ def test_flow_guide_svi_coupling_factory(key):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_flow_guide_sample_posterior_shape(key, key2):
     """sample_posterior returns samples with the expected shape."""
     obs = jnp.array([1.0])
@@ -143,6 +154,8 @@ def test_flow_guide_sample_posterior_shape(key, key2):
     assert jnp.all(jnp.isfinite(posterior_samples["mu"]))
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_flow_guide_sample_posterior_multidim(key, key2):
     """sample_posterior returns correctly shaped samples for vector latents."""
     obs = jnp.zeros(3)

--- a/tests/test_survae_base.py
+++ b/tests/test_survae_base.py
@@ -152,6 +152,7 @@ def _make_bijection_chain(key):
     ]
 
 
+@pytest.mark.integration
 def test_log_prob_matches_flowjax_transformed_for_bijection_only_chain(key):
     base = Normal(jnp.zeros(3))
     bijections = _make_bijection_chain(key)
@@ -165,6 +166,7 @@ def test_log_prob_matches_flowjax_transformed_for_bijection_only_chain(key):
     assert jnp.allclose(actual, expected, atol=1e-5)
 
 
+@pytest.mark.integration
 def test_sample_shape_for_bijection_only_chain(key):
     base = Normal(jnp.zeros(3))
     flow = SurVAEFlow(base, _make_bijection_chain(key))
@@ -230,6 +232,7 @@ def test_log_prob_uses_surjection_forward_direction(key):
     assert jnp.allclose(actual, expected, atol=1e-6)
 
 
+@pytest.mark.integration
 def test_sample_log_prob_round_trip_with_asymmetric_surjection(key):
     """End-to-end: log_prob of a fresh sample equals base.log_prob of the base draw."""
     base = Normal(jnp.zeros(3))
@@ -242,6 +245,7 @@ def test_sample_log_prob_round_trip_with_asymmetric_surjection(key):
     assert jnp.allclose(log_probs, expected, atol=1e-5)
 
 
+@pytest.mark.integration
 def test_sample_log_prob_finite_with_identity_surjection(key):
     base = Normal(jnp.zeros(3))
     flow = SurVAEFlow(base, [Affine(loc=jnp.zeros(3)), _IdentitySurjection()])

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -22,6 +22,8 @@ def test_fit_gaussianization_flow(key, data_2d):
     assert trained_flow.shape == flow.shape
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 def test_fit_gaussianization_flow_returns_correct_type(key, data_2d):
     from flowjax.distributions import Transformed
 

--- a/tests/test_transforms_coupling_conditional.py
+++ b/tests/test_transforms_coupling_conditional.py
@@ -130,6 +130,7 @@ def test_rejects_zero_or_negative_cond_dim(key, make):
         make(key, cond_dim=-1)
 
 
+@pytest.mark.integration
 def test_four_layer_affine_stack_is_conditional_end_to_end(key):
     """Acceptance criterion from #28: condition flows through a 4-layer stack."""
     from flowjax.bijections import Chain, Permute

--- a/tests/test_transforms_rotation.py
+++ b/tests/test_transforms_rotation.py
@@ -158,6 +158,7 @@ def test_lu_linear_permute_custom_permutation(key):
     assert jnp.allclose(x, x_rec, atol=1e-6)
 
 
+@pytest.mark.integration
 def test_gaussianization_flow_accepts_lu_rotation(key):
     flow = gaussianization_flow(key, n_dims=3, n_layers=2, rotation="lu")
     samples = flow.sample(jr.fold_in(key, 3), (16,))

--- a/tests/test_transforms_surjections.py
+++ b/tests/test_transforms_surjections.py
@@ -297,6 +297,7 @@ def test_simple_maxpool_rejects_bad_shape():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_survaeflow_integration_abs_sort_perm(key):
     """Each new transform must round-trip through SurVAEFlow without NaN."""
     dim = 4
@@ -438,6 +439,7 @@ def test_augment_shape_attribute_and_forward_validation(key):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_survaeflow_log_prob_validates_data_shape(key):
     """Wrong-shape input must raise; correct shape must succeed."""
     base = Normal(jnp.zeros(2))
@@ -455,6 +457,7 @@ def test_survaeflow_log_prob_validates_data_shape(key):
         flow.log_prob(bad, jr.fold_in(key, 3))
 
 
+@pytest.mark.integration
 def test_survaeflow_with_slice_sample_log_prob(key):
     """SurVAEFlow + Slice: sample produces data-shaped output; log_prob is finite."""
     base = Normal(jnp.zeros(2))
@@ -470,6 +473,7 @@ def test_survaeflow_with_slice_sample_log_prob(key):
     assert jnp.all(jnp.isfinite(log_probs))
 
 
+@pytest.mark.integration
 def test_survaeflow_with_augment_sample_log_prob(key):
     """SurVAEFlow + Augment: data shape (2,) → latent (4,) via encoder."""
     base = Normal(jnp.zeros(4))


### PR DESCRIPTION
## Summary

Training loops, ODE solvers, and large-sample convergence checks were running on every PR, making CI unnecessarily slow. This PR introduces two pytest markers and wires them into CI.

- **`slow`** — training loops, MCMC/SVI runs, 20k-sample convergence checks, RBIG fitting (anything that takes >a few seconds)
- **`integration`** — end-to-end tests that build a model, fit it, and evaluate (fast but test the full pipeline)

## CI change

| Trigger | What runs |
|---------|-----------|
| Pull request | `pytest -m "not slow"` — fast + integration tests only |
| Push to `main` | fast + integration tests, then slow tests in a separate step |

## Markers added

| File | `slow` added | `integration` added |
|------|-------------|---------------------|
| `test_continuous_affine_coupling.py` | 1 | 1 |
| `test_distributions_pca.py` | 1 | 1 |
| `test_distributions_sphere.py` | 2 | — |
| `test_distributions_mixture.py` | 1 | 2 |
| `test_train.py` | 1 | 1 |
| `test_flows.py` | — | 5 |
| `test_flows_survae_conditional.py` | — | 6 |
| `test_numpyro.py` | — | 1 |
| `test_numpyro_guide.py` | 6 | 6 |
| `test_survae_base.py` | — | 4 |
| `test_transforms_surjections.py` | — | 4 |
| `test_transforms_rotation.py` | — | 1 |
| `test_transforms_coupling_conditional.py` | — | 1 |
| `test_init_rbig.py` | 5 | 10 |

Already-marked slow tests (FFJORD ODE, VAE SVI, info-theory RBIG, train loop) were left untouched.

## Test plan

- [ ] PR CI completes noticeably faster (slow tests skipped)
- [ ] `pytest -m slow` locally runs only the training/convergence tests
- [ ] `pytest -m integration` runs only end-to-end pipeline tests
- [ ] `pytest` (no filter) still runs everything locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)