### PR TITLE
test: exclude slow + integration from CI and parallelise the fast suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
       - name: Run tests with coverage
-        run: uv run pytest -v -m "not slow"
-      - name: Run slow tests (main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: uv run pytest -v -m "slow" --no-cov
+        # Slow + integration tests never run in CI — they exercise training
+        # convergence and end-to-end fit→evaluate paths that are too costly for
+        # Actions. Run them locally with `make test`.
+        # `-n auto` parallelises across runner cores (pytest-xdist); most of the
+        # remaining wall time is per-test JAX compilation, which xdist overlaps.
+        run: uv run pytest -m "not slow and not integration" -n auto
       - name: Upload coverage report
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ test: ## 🧪 Run tests with pytest (with coverage)
 	uv run pytest -v
 	@printf "$(GREEN)>>> ✅ Tests passed!$(RESET)\n"
 
-test-fast: ## 🏃 Run tests, skipping slow-marked tests
-	@printf "$(YELLOW)>>> Running fast tests (no slow)...$(RESET)\n"
-	uv run pytest -v -m "not slow" -o addopts=
+test-fast: ## 🏃 Run fast tests only (skip slow + integration — mirrors CI)
+	@printf "$(YELLOW)>>> Running fast tests (no slow, no integration)...$(RESET)\n"
+	uv run pytest -v -m "not slow and not integration" -o addopts=
 	@printf "$(GREEN)>>> ✅ Fast tests passed!$(RESET)\n"
 
 test-cov: ## 📊 Run tests with coverage report

--- a/tests/test_transforms_marginal.py
+++ b/tests/test_transforms_marginal.py
@@ -97,8 +97,8 @@ def test_histogram_cdf_forward_inverse(key):
 
 def test_histogram_cdf_matches_gaussian_cdf(key):
     shape = (1,)
-    data = jr.normal(key, (20000, shape[0]))
-    transform = HistogramCDF(n_bins=256, shape=shape).fit(data)
+    data = jr.normal(key, (8000, shape[0]))
+    transform = HistogramCDF(n_bins=128, shape=shape).fit(data)
     points = jnp.linspace(-2.0, 2.0, 21)[:, None]
 
     def _single_cdf(x_point):


### PR DESCRIPTION
## Why

The test suite was slow on CI because **integration tests still ran on every PR** — CI only deselected `slow`, so the gating suite carried the full build→fit→evaluate and sklearn RBIG-init paths. This restricts CI to fast, correctness-only unit tests and parallelises them.

## Changes

- **`.github/workflows/ci.yml`** — CI now runs `pytest -m "not slow and not integration" -n auto`.
  - Slow + integration tests no longer run in Actions (removed the main-only slow step); they run locally via `make test`.
  - `-n auto` enables `pytest-xdist` (already a dev dependency) to overlap the per-test JAX compilation that dominates wall time.
- **`Makefile`** — `make test-fast` now mirrors CI (skips both `slow` and `integration`).
- **`tests/test_transforms_marginal.py`** — shrink `test_histogram_cdf_matches_gaussian_cdf` fit data 20k→8k samples and bins 256→128 (keep the data small); the 0.02 CDF-match tolerance still holds with ~9× headroom (measured error 0.00229).

## Verification

Ran the exact CI suite (`-m "not slow and not integration"` with coverage + xdist):

- **411 passed in 2:53** (parallel).
- **Coverage 90.18%** — comfortably above the `fail_under = 80` gate, so dropping integration from CI does not break coverage.

## Trade-off (intentional)

Slow + integration code paths (training, RBIG init, FFJORD ODE, NumPyro SVI) now have no automated CI coverage — they rely on local `make test`. If a safety net is wanted later without slowing PRs, a nightly `schedule:` job running `-m "slow or integration"` would catch regressions off the critical path.

https://claude.ai/code/session_01KSt4pcUNbRFb2ZRgrW7oFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSt4pcUNbRFb2ZRgrW7oFX)_