### PR TITLE
docs: themed API reference, uniform docstrings, README/index overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,49 @@
 # gauss_flows
 
-**JAX/FlowJax-based RBIG — density estimation and IT measures with normalizing flows**
-
-[![CI](https://github.com/jejjohnson/gauss_flows/actions/workflows/ci.yml/badge.svg)](https://github.com/jejjohnson/gauss_flows/actions/workflows/ci.yml)
+[![Tests](https://github.com/jejjohnson/gauss_flows/actions/workflows/ci.yml/badge.svg)](https://github.com/jejjohnson/gauss_flows/actions/workflows/ci.yml)
+[![Lint](https://github.com/jejjohnson/gauss_flows/actions/workflows/lint.yml/badge.svg)](https://github.com/jejjohnson/gauss_flows/actions/workflows/lint.yml)
+[![Type Check](https://github.com/jejjohnson/gauss_flows/actions/workflows/typecheck.yml/badge.svg)](https://github.com/jejjohnson/gauss_flows/actions/workflows/typecheck.yml)
 [![codecov](https://codecov.io/gh/jejjohnson/gauss_flows/branch/main/graph/badge.svg)](https://codecov.io/gh/jejjohnson/gauss_flows)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-`gauss_flows` implements Rotation-Based Iterative Gaussianization (RBIG) and related
-Gaussianization flows in JAX, built on top of the
-[FlowJax](https://github.com/danielward27/flowjax) library.
+**Gaussianization flows in JAX** — density estimation, normalizing flows, and
+information-theoretic measures, built on [FlowJax](https://github.com/danielward27/flowjax)
+and compatible with [NumPyro](https://num.pyro.ai/). `gauss_flows` implements
+Rotation-Based Iterative Gaussianization (RBIG) and related flows that map data to a standard
+normal by alternating marginal CDF transforms with learned rotations, plus the
+[SurVAE](https://arxiv.org/abs/2007.02731) hierarchy of bijections, surjections, and
+stochastic transforms.
 
-## Features
+## Install
 
-- **Gaussianization Flows**: Iterative RBIG and coupling-based Gaussianization flows
-- **Marginal Transforms**: Mixture Gaussian/Logistic CDFs, rational quadratic splines, histogram CDF
-- **Rotation Transforms**: Householder, orthogonal, and fixed rotations
-- **Coupling Transforms**: Affine coupling, RQ spline coupling, deep sigmoid coupling
-- **Conv Transforms**: Invertible 1x1 convolution, ActNorm, Haar wavelet, Squeeze
-- **Information Theory**: Entropy, total correlation, mutual information, KL divergence, negentropy
-- **NumPyro Integration**: `FlowDist` wrapper for use in NumPyro probabilistic programs
-
-## Package layout
-
-The implementation follows the SurVAE Flows taxonomy (Nielsen et al. 2020) —
-every transform is classified as a bijection, surjection, or stochastic
-transform, and each category is further split by technique:
-
-```text
-_src/
-├── transforms/
-│   ├── base.py                        # AbstractSurjection / AbstractStochastic / _IdentitySurjection
-│   ├── bijections/
-│   │   ├── coupling/                  # Affine / Spline / CircularSpline / DeepSigmoid
-│   │   ├── elementwise/               # Histogram / InverseGauss / MixtureCDFs / (Circular)Spline
-│   │   ├── linear/                    # Rotation / LU / Conv1x1 / ConvExp / Haar
-│   │   ├── normalization/             # ActNorm(2D+1D) / BatchNorm
-│   │   ├── reshape/                   # Squeeze
-│   │   ├── periodic/                  # PeriodicShift / PeriodicWrap (+ shared _utils)
-│   │   └── classic/                   # PlanarFlow / SylvesterFlow
-│   ├── surjections/
-│   │   ├── dimension/                 # Augment / Slice
-│   │   ├── abs.py / sort.py / pool.py
-│   └── stochastic/
-│       └── vae.py / permutation.py
-├── flows/
-│   ├── survae.py                      # SurVAEFlow container
-│   ├── gaussianization.py             # gaussianization_flow, coupling_gaussianization_flow
-│   └── rbig.py                        # iterative_rbig
-├── inference/
-│   ├── numpyro_compat.py              # FlowDist
-│   ├── numpyro_guide.py               # FlowGuide
-│   └── train.py                       # fit_gaussianization_flow
-└── nn/                                # reserved placeholder for future NN building blocks
-```
-
-The public `gauss_flows.*` surface re-exports every leaf class, so this
-layout is internal — import from `gauss_flows` directly rather than the
-`_src/` paths.
-
-## Installation
+Not yet on PyPI — install from source:
 
 ```bash
-pip install -e .
+pip install git+https://github.com/jejjohnson/gauss_flows
 ```
 
-Or with [uv](https://github.com/astral-sh/uv):
+For development, see [Contributing](#contributing).
 
-```bash
-uv sync
-```
+## What's inside
 
-## Quick Start
+| Module | Contents |
+|--------|----------|
+| Bijections — coupling | `AffineCoupling`, `GINCoupling`, `RQSplineCoupling`, `CircularRQSplineCoupling`, `DeepSigmoidCoupling`, `MixtureGaussianCDFCoupling`, `ContinuousAffineCoupling` |
+| Bijections — marginal | `MixtureGaussianCDF`, `MixtureLogisticCDF`, `RQSplineMarginal`, `CircularRationalQuadraticSpline`, `HistogramCDF`, `InverseGaussCDF` |
+| Bijections — linear | `HouseholderRotation`, `OrthogonalRotation`, `FixedRotation`, `LULinearPermute`, `Invertible1x1Conv`, `OrthogonalConvExponential`, `MatrixExponential`, `HaarWavelet` |
+| Bijections — other | `ActNorm`/`BatchNorm`, `PeriodicShift`/`PeriodicWrap`, `Squeeze`, `PlanarFlow`/`SylvesterFlow`, `FFJORD` (continuous) |
+| Surjections & stochastic | `SimpleAbsSurjection`, `SimpleSortSurjection`, `SimpleMaxPoolSurjection2d`, `Augment`/`Slice`, `VAE`, `StochasticPermutation` |
+| Base distributions | `GaussianPCA`, `GaussianMixture`, `ConditionalDiagGaussian`, `ClassCondDiagGaussian`, `VonMisesFisher`, `UniformOnSphere` |
+| Flows & RBIG | `SurVAEFlow`, `gaussianization_flow`, `coupling_gaussianization_flow`, `iterative_rbig`, `fit_rbig`, `fit_rbig_coupling` |
+| NumPyro inference | `FlowDist`, `FlowGuide`, `fit_gaussianization_flow` |
+| Information theory | `entropy`, `total_correlation`, `mutual_information`, `kl_divergence`, `negentropy` (+ analytical & RBIG-way variants) |
+
+The public `gauss_flows.*` surface re-exports every leaf class and function, so the internal
+`_src/` layout is just organisation — import from `gauss_flows` directly.
+
+## Quick start
+
+Build a Gaussianization flow, fit it to data, then read off a density and an entropy estimate:
 
 ```python
 import jax.random as jr
@@ -77,101 +51,73 @@ from gauss_flows import gaussianization_flow, fit_gaussianization_flow, entropy
 
 key = jr.key(0)
 
-# Build a Gaussianization flow
+# Build an 8-block Gaussianization flow over 10-D data.
 flow = gaussianization_flow(key, n_dims=10, n_layers=8, n_components=8)
 
-# Fit to data
+# Fit to samples by maximum likelihood.
 data = jr.normal(key, (1000, 10))
 trained_flow, losses = fit_gaussianization_flow(key, flow, data)
 
-# Compute log-probability
-log_probs = trained_flow.log_prob(data)
-
-# Estimate entropy (in nats)
-h = entropy(trained_flow, n_samples=10000, key=jr.key(1))
+log_probs = trained_flow.log_prob(data)          # (1000,)
+h = entropy(trained_flow, n_samples=10_000, key=jr.key(1))   # scalar, in nats
 print(f"Entropy: {h:.3f} nats")
 ```
 
-### Information Theory
+Transforms act on a **single event** (`x.shape == transform.shape`) and return a scalar
+`log_det`; batch with `jax.vmap`:
 
 ```python
-from gauss_flows import entropy, total_correlation, kl_divergence, mutual_information
+import jax, jax.numpy as jnp, jax.random as jr
+from gauss_flows import MixtureGaussianCDF, HouseholderRotation, RQSplineCoupling
 
-# Entropy
-h = entropy(flow, n_samples=10000, key=key)
+marginal = MixtureGaussianCDF(n_components=8, shape=(10,))   # per-dim Gaussianization
+rotation = HouseholderRotation(n_reflections=10, shape=(10,))  # decorrelating rotation
+spline = RQSplineCoupling(jr.key(0), shape=(10,), n_bins=8)  # expressive coupling
 
-# Total correlation (multi-information)
-tc = total_correlation(flow, n_samples=10000, key=key)
-
-# KL divergence between two distributions
-kl = kl_divergence(flow1, flow2, n_samples=10000, key=key)
+x = jr.normal(jr.key(1), (10,))             # one event
+y, log_det = marginal.transform_and_log_det(x)        # y: (10,), log_det: scalar
+ys, log_dets = jax.vmap(marginal.transform_and_log_det)(jnp.ones((32, 10)))  # batch
 ```
 
-### NumPyro Integration
+For a closed-form **warm start** with no gradient training, fit RBIG directly from data:
 
 ```python
-import numpyro
-from gauss_flows import gaussianization_flow, FlowDist
+from gauss_flows import fit_rbig
 
-flow = gaussianization_flow(key, n_dims=5)
-flow_dist = FlowDist(flow)
-
-# Use in a NumPyro model:
-def model(obs=None):
-    x = numpyro.sample("x", flow_dist, obs=obs)
+flow = fit_rbig(data, n_layers=8, n_components=8)   # per-block GMM CDFs + rotations
+log_probs = flow.log_prob(data)
 ```
 
-### Transforms
+`gauss_flows` flows also drop into NumPyro models as a distribution (`FlowDist`) or a
+variational guide (`FlowGuide`) — see the [docs](https://jejjohnson.github.io/gauss_flows/).
 
-```python
-from gauss_flows import (
-    MixtureGaussianCDF,
-    HouseholderRotation,
-    AffineCoupling,
-    CircularRQSplineCoupling,
-    PeriodicShift,
-    PeriodicWrap,
-    RQSplineCoupling,
-)
+## Contributing
 
-# Marginal Gaussianization
-marginal = MixtureGaussianCDF(n_components=8, shape=(10,))
-
-# Rotation
-rotation = HouseholderRotation(n_reflections=10, shape=(10,))
-
-# Coupling layers
-affine = AffineCoupling(key, shape=(10,))
-spline = RQSplineCoupling(key, shape=(10,), n_bins=8)
-circular = CircularRQSplineCoupling(key, shape=(10,))  # all dims periodic
-
-# Periodic utilities
-# Note: PeriodicWrap is a canonical projection (many-to-one), not a true
-# bijection on R. Use it as a leading layer to canonicalise raw angles into
-# [-π, π] before downstream periodic flow layers; do not compose it inside a
-# Transformed/SurVAEFlow that expects to invert back to the original input.
-wrap = PeriodicWrap(ind=(0,), shape=(10,))
-shift = PeriodicShift(ind=(0,), shape=(10,))
-```
-
-## Development
+Built with `uv`, `ruff`, `ty`, `pytest`, and MkDocs.
 
 ```bash
-# Install with dev dependencies
-uv sync --all-extras
-
-# Run tests
-make test
-
-# Run linter
-make lint
-
-# Run all checks
-make check
+make install      # install all dependency groups + pre-commit hooks
+make test         # run the test suite (use `make test-fast` to skip slow + integration)
+make format       # auto-format and fix lint
+make lint         # ruff check
+make typecheck    # ty check
+make docs-serve   # preview docs locally
 ```
+
+Before committing, all four gates must pass: tests, `ruff check .`,
+`ruff format --check .`, and `ty check src/gauss_flows`. See
+[`AGENTS.md`](AGENTS.md) for the full workflow and coding conventions.
 
 ## References
 
 - Meng, C., Song, Y., Song, J., & Ermon, S. (2020). *Gaussianization Flows*. arXiv:2003.01941
 - Laparra, V., Camps-Valls, G., & Malo, J. (2011). *Iterative Gaussianization: From ICA to Random Rotations*. IEEE TNNLS.
+- Nielsen, D., Jaini, P., Hoogeboom, E., Winther, O., & Welling, M. (2020). *SurVAE Flows: Surjections to Bridge the Gap between VAEs and Flows*. NeurIPS. arXiv:2007.02731
 - Ward, D. (2023). *FlowJAX: Distributions and Normalizing Flows in JAX*.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+Author: [J. Emmanuel Johnson](https://jejjohnson.netlify.com) ·
+Repo: <https://github.com/jejjohnson/gauss_flows>

--- a/docs/api/bijections.md
+++ b/docs/api/bijections.md
@@ -8,8 +8,14 @@ $$
 \log p_X(x) \;=\; \log p_Z\!\big(f(x)\big) \;+\; \log\left|\det \frac{\partial f}{\partial x}\right|,
 $$
 
-so every layer returns `(y, log_det)` from both `transform_and_log_det` (data → latent) and
-`inverse_and_log_det` (latent → data). All layers below subclass
+so each layer exposes its map and the log-determinant of its Jacobian in **both** directions —
+`transform_and_log_det` and `inverse_and_log_det`, each returning `(y, log_det)`. Per the
+[FlowJax](https://danielward27.github.io/flowjax/) convention a
+[`Transformed`](https://danielward27.github.io/flowjax/) distribution applies `transform` when
+**sampling** (base → data) and `inverse` when **evaluating density** (data → base — the $f$ in
+the formula above), so a layer's data/latent orientation is set by how it is composed, not by
+the method name. Generative-only layers such as `PlanarFlow` / `SylvesterFlow` implement only
+`transform_and_log_det`. All layers below subclass
 [`flowjax.bijections.AbstractBijection`](https://danielward27.github.io/flowjax/) and follow
 the **single-event** convention (`x.shape == self.shape`, scalar `log_det`); batch with
 `jax.vmap`.

--- a/docs/api/bijections.md
+++ b/docs/api/bijections.md
@@ -1,0 +1,149 @@
+# Bijections
+
+A bijection is an exactly invertible map $f:\mathbb{R}^D\!\to\mathbb{R}^D$ paired with the
+log-absolute-determinant of its Jacobian. Under the change-of-variables formula a base
+density $p_Z$ pushes forward to
+
+$$
+\log p_X(x) \;=\; \log p_Z\!\big(f(x)\big) \;+\; \log\left|\det \frac{\partial f}{\partial x}\right|,
+$$
+
+so every layer returns `(y, log_det)` from both `transform_and_log_det` (data → latent) and
+`inverse_and_log_det` (latent → data). All layers below subclass
+[`flowjax.bijections.AbstractBijection`](https://danielward27.github.io/flowjax/) and follow
+the **single-event** convention (`x.shape == self.shape`, scalar `log_det`); batch with
+`jax.vmap`.
+
+## Coupling layers
+
+Coupling layers split the input into two halves, leave one half untouched, and transform the
+other half with an elementwise bijection whose parameters are predicted by a neural network
+from the untouched half. The Jacobian is triangular, so `log_det` is a cheap sum and the
+inverse is closed-form — the workhorse of expressive flows.
+
+::: gauss_flows.AffineCoupling
+
+::: gauss_flows.GINCoupling
+
+::: gauss_flows.RQSplineCoupling
+
+::: gauss_flows.CircularRQSplineCoupling
+
+::: gauss_flows.DeepSigmoidCoupling
+
+::: gauss_flows.MixtureGaussianCDFCoupling
+
+::: gauss_flows.ContinuousAffineCoupling
+
+## Marginal (elementwise) transforms
+
+Marginal transforms act independently on each coordinate — the Gaussianization "G" step that
+reshapes per-dimension marginals toward a target (usually a standard normal or a uniform).
+Because they are diagonal, the Jacobian determinant is the product of per-coordinate
+derivatives.
+
+::: gauss_flows.MixtureGaussianCDF
+
+::: gauss_flows.MixtureLogisticCDF
+
+::: gauss_flows.RQSplineMarginal
+
+::: gauss_flows.CircularRationalQuadraticSpline
+
+::: gauss_flows.HistogramCDF
+
+::: gauss_flows.InverseGaussCDF
+
+## Linear & rotation layers
+
+Linear layers mix information across coordinates — the rotation "R" step of RBIG. A rotation
+$W$ contributes $\log|\det W|$ (zero for an orthogonal $W$) and, by decorrelating dimensions,
+lets the next marginal step make progress.
+
+::: gauss_flows.HouseholderRotation
+
+::: gauss_flows.OrthogonalRotation
+
+::: gauss_flows.FixedRotation
+
+::: gauss_flows.LULinearPermute
+
+::: gauss_flows.Invertible1x1Conv
+
+::: gauss_flows.Orthogonal1x1Conv
+
+::: gauss_flows.OrthogonalConvExponential
+
+::: gauss_flows.MatrixExponential
+
+::: gauss_flows.HaarWavelet
+
+## Normalisation layers
+
+Normalisation layers rescale and recentre activations between flow blocks, stabilising both
+training and the conditioning of downstream rotations.
+
+::: gauss_flows.ActNorm
+
+::: gauss_flows.ActNorm1D
+
+::: gauss_flows.BatchNorm
+
+## Periodic layers
+
+Periodic layers operate on angular (circular) coordinates living on $[-\pi, \pi)$, for flows
+on the torus or sphere.
+
+::: gauss_flows.PeriodicShift
+
+::: gauss_flows.PeriodicWrap
+
+## Reshape layers
+
+::: gauss_flows.Squeeze
+
+## Classic residual flows
+
+Residual flows apply a low-rank perturbation $x + u\,h(w^\top x + b)$. The determinant follows
+from the matrix-determinant lemma, so `log_det` stays cheap despite the full-rank coupling
+across coordinates.
+
+::: gauss_flows.PlanarFlow
+
+::: gauss_flows.SylvesterFlow
+
+## Continuous (FFJORD) flows
+
+A continuous normalizing flow replaces the discrete layer stack with an ODE
+$\dot{x} = v_\theta(t, x)$ integrated over $t\in[0,1]$. The log-density change accumulates the
+instantaneous trace of the Jacobian,
+
+$$
+\log p_X(x(0)) \;=\; \log p_Z(x(1)) + \int_0^1 \nabla\!\cdot\, v_\theta\big(t, x(t)\big)\,\mathrm{d}t,
+$$
+
+estimated exactly (small $D$) or with the Hutchinson trace estimator. The `Diffeq*` networks
+parameterise $v_\theta$, the `Time*` nets embed $t$, and `pack_time_control` bundles the time
+and optional control signal into the `condition` FlowJax threads through the solver.
+
+::: gauss_flows.FFJORD
+
+::: gauss_flows.DiffeqMLP
+
+::: gauss_flows.DiffeqConcat
+
+::: gauss_flows.TimeIdentity
+
+::: gauss_flows.TimeTanh
+
+::: gauss_flows.TimeFourier
+
+::: gauss_flows.pack_time_control
+
+::: gauss_flows.unpack_time_control
+
+::: gauss_flows.time_control_cond_shape
+
+## Conditional wrappers
+
+::: gauss_flows.Conditioner

--- a/docs/api/distributions.md
+++ b/docs/api/distributions.md
@@ -1,0 +1,43 @@
+# Base Distributions
+
+A normalizing flow needs a tractable **base distribution** $p_Z$ to push forward through its
+bijections. The default is a standard normal (`flowjax.distributions.Normal`), but a richer
+or structured base can shorten the flow it has to learn. These distributions expose
+`log_prob` and `sample` and plug into any FlowJax
+[`Transformed`](https://danielward27.github.io/flowjax/) or the package's `SurVAEFlow`
+container as the `base_dist` argument.
+
+## Euclidean bases
+
+`GaussianPCA` is a low-rank-plus-diagonal Gaussian, $\Sigma = W W^\top + \sigma^2 I$, whose
+`log_prob` uses the Woodbury identity to avoid forming the full $D\times D$ covariance.
+`GaussianMixture` is a 1-D mixture used as a marginal target. The conditional variants emit
+mean/scale from a context vector for amortised inference and class-conditional flows.
+
+::: gauss_flows.GaussianPCA
+
+::: gauss_flows.GaussianMixture
+
+::: gauss_flows.ConditionalDiagGaussian
+
+::: gauss_flows.ClassCondDiagGaussian
+
+::: gauss_flows.NumpyroBase
+
+## Manifold (sphere) distributions
+
+Distributions on the unit sphere $\mathbb{S}^{d}\subset\mathbb{R}^{d+1}$ for directional data
+and global flows. The von Mises–Fisher density $p(x)\propto\exp(\kappa\,\mu^\top x)$
+concentrates around a mean direction $\mu$ with concentration $\kappa$; `UniformOnSphere` is
+its $\kappa\to 0$ limit. The exp/log maps and tangent basis below move between the manifold
+and its tangent plane for building flows in local coordinates.
+
+::: gauss_flows.VonMisesFisher
+
+::: gauss_flows.UniformOnSphere
+
+::: gauss_flows.expmap_sphere
+
+::: gauss_flows.logmap_sphere
+
+::: gauss_flows.tangent_basis

--- a/docs/api/flows.md
+++ b/docs/api/flows.md
@@ -1,0 +1,48 @@
+# Flows & RBIG
+
+These are the **Layer 1** assemblies — containers that stack transforms into a full flow, and
+one-call factories that build a ready-to-train (or already-fitted) Gaussianization flow. A
+Gaussianization flow alternates a marginal CDF step $G$ with a rotation $R$,
+
+$$
+z \;=\; (R_L \circ G_L)\circ\cdots\circ(R_1 \circ G_1)\,(x),
+$$
+
+driving the data toward a standard normal one block at a time. After $L$ blocks the flow is a
+density estimator (`log_prob`), a sampler (`sample`), and — because the latent is Gaussian — a
+plug-in estimator for the information-theoretic measures in
+[Information Theory](info_theory.md).
+
+## Containers
+
+`SurVAEFlow` is the general container: it threads a `key` through a chain that may mix
+bijections, surjections, and stochastic transforms, and vmaps `log_prob` / `sample` over any
+leading `sample_shape`. For a bijection-only chain it matches `flowjax.Transformed` exactly.
+
+::: gauss_flows.SurVAEFlow
+
+::: gauss_flows.ClassCondFlow
+
+## Flow factories
+
+`gaussianization_flow` builds the classic marginal-mixture + rotation stack;
+`coupling_gaussianization_flow` swaps the marginal step for spline coupling layers;
+`iterative_rbig` constructs the trainable iterative-RBIG flow. Each returns a FlowJax
+`Transformed` distribution.
+
+::: gauss_flows.gaussianization_flow
+
+::: gauss_flows.coupling_gaussianization_flow
+
+::: gauss_flows.iterative_rbig
+
+## RBIG warm-start
+
+Rotation-Based Iterative Gaussianization fits each block in closed form from data — per-dimension
+Gaussian-mixture CDFs followed by a random/PCA rotation — giving a strong **warm start** with no
+gradient training. The result is an ordinary flow that can be used as-is or fine-tuned with
+[`fit_gaussianization_flow`](inference.md#gauss_flows.fit_gaussianization_flow).
+
+::: gauss_flows.fit_rbig
+
+::: gauss_flows.fit_rbig_coupling

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,62 @@
+# API Reference
+
+`gauss_flows` is a [JAX](https://docs.jax.dev/) / [FlowJax](https://github.com/danielward27/flowjax)
+toolkit for **Gaussianization flows** — normalizing flows that iteratively map data to a
+standard normal by alternating marginal CDF transforms with learned rotations (the RBIG
+pattern), together with the [SurVAE](https://arxiv.org/abs/2007.02731) hierarchy of
+bijections, surjections, and stochastic transforms, and the information-theoretic measures
+those flows unlock. The reference is organised by theme rather than dumped as one flat page:
+
+| Section | What's inside |
+|---------|---------------|
+| [Bijections](bijections.md) | Exactly-invertible transforms — coupling, marginal CDFs, linear/rotation, normalisation, periodic, classic residual, and continuous (FFJORD) layers |
+| [Surjections & Stochastic](surjections.md) | Deterministic surjections (abs, sort, max-pool, augment/slice) and stochastic transforms (VAE, permutation) with lower-bound likelihoods |
+| [Base Distributions](distributions.md) | Latent distributions for the flow base — Gaussian mixtures, low-rank PCA Gaussian, conditional/class-conditional diagonals, and manifold (sphere) distributions |
+| [Flows & RBIG](flows.md) | Flow containers (`SurVAEFlow`) and one-call factories — `gaussianization_flow`, `coupling_gaussianization_flow`, `iterative_rbig`, plus the `fit_rbig` warm-start |
+| [NumPyro Inference](inference.md) | `FlowDist` distribution wrapper, `FlowGuide` variational guide, and the `fit_gaussianization_flow` training loop |
+| [Information Theory](info_theory.md) | Entropy, total correlation, mutual information, KL, negentropy — Monte-Carlo (flow-based), analytical Gaussian closed forms, and RBIG-way reductions |
+
+## Conventions
+
+A few patterns hold across the whole package:
+
+- **Built on FlowJax.** Every bijection subclasses
+  [`flowjax.bijections.AbstractBijection`](https://danielward27.github.io/flowjax/);
+  base distributions subclass `flowjax`/`equinox` modules. Compose transforms with
+  FlowJax [`Chain`](https://danielward27.github.io/flowjax/) / `Scan` and wrap them with
+  [`Transformed`](https://danielward27.github.io/flowjax/) — or use the package's
+  `SurVAEFlow` container when a chain mixes surjections and stochastic steps.
+
+- **Single-event, not batched.** Transform methods
+  (`transform_and_log_det` / `inverse_and_log_det` / `forward_and_log_det`) assume
+  `x.shape == self.shape` and return a **scalar** `log_det`. Vectorise over a batch with
+  [`jax.vmap`](https://docs.jax.dev/en/latest/_autosummary/jax.vmap.html) /
+  `eqx.filter_vmap`; the `SurVAEFlow` container already vmaps `log_prob` / `sample` over
+  any leading `sample_shape`. This matches the FlowJax convention, which runtime-enforces
+  `x.shape == bijection.shape`.
+
+    ```python
+    import jax, jax.numpy as jnp, jax.random as jr
+    from gauss_flows import MixtureGaussianCDF
+
+    t = MixtureGaussianCDF(n_components=8, shape=(4,))
+    x = jr.normal(jr.key(0), (4,))          # one event, shape == t.shape
+    y, log_det = t.transform_and_log_det(x)  # y: (4,), log_det: scalar
+
+    xs = jr.normal(jr.key(1), (32, 4))       # a batch
+    ys, log_dets = jax.vmap(t.transform_and_log_det)(xs)  # (32, 4), (32,)
+    ```
+
+- **Immutable Equinox modules.** Transforms and distributions are
+  [`equinox.Module`](https://docs.kidger.site/equinox/) pytrees — immutable, JIT/grad/vmap
+  friendly. Trainable parameters are array leaves; filter them with
+  `eqx.filter(model, eqx.is_inexact_array)` when building an optimiser. Constructors that
+  draw random weights take a `key` (`jax.random.PRNGKey`/`jax.random.key`).
+
+- **Unicode math in docstrings.** Docstrings use mathematical Unicode freely
+  (`−`, `×`, `σ`, `ℝ`, `∑`) — `RUF002` is ignored project-wide for this reason. Public
+  transforms and distributions document a **Shape:** section (per-method input/output
+  shapes, single-event convention) and a runnable **Example:** block.
+
+The public `gauss_flows.*` surface re-exports every leaf — import from `gauss_flows`
+directly rather than the internal `_src/` paths.

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -1,0 +1,24 @@
+# NumPyro Inference
+
+`gauss_flows` flows interoperate with [NumPyro](https://num.pyro.ai/) so a learned flow can
+serve as either a **prior/likelihood** in a probabilistic model or as a **variational guide**
+for an arbitrary model.
+
+- `FlowDist` wraps any FlowJax flow as a `numpyro.distributions.Distribution`, exposing
+  `sample` and `log_prob` so it can be used directly at a `numpyro.sample` site.
+- `FlowGuide` is an `AutoContinuous` variational guide whose posterior is a normalizing flow —
+  a flexible, full-rank alternative to a mean-field `AutoNormal` guide for SVI.
+- `fit_gaussianization_flow` is the maximum-likelihood training loop (a thin wrapper over
+  `flowjax.train.fit_to_data`) for fitting a flow to samples.
+
+## Distribution wrapper
+
+::: gauss_flows.FlowDist
+
+## Variational guide
+
+::: gauss_flows.FlowGuide
+
+## Training
+
+::: gauss_flows.fit_gaussianization_flow

--- a/docs/api/info_theory.md
+++ b/docs/api/info_theory.md
@@ -1,0 +1,58 @@
+# Information Theory
+
+A Gaussianization flow is also an **information-theoretic estimator**. Because the flow gives a
+tractable density, differential entropy follows from the Monte-Carlo identity
+
+$$
+H(X) \;=\; -\,\mathbb{E}_{x\sim p_X}\big[\log p_X(x)\big]
+\;\approx\; -\frac{1}{N}\sum_{i=1}^{N}\log p_X(x_i),\qquad x_i \sim p_X,
+$$
+
+and total correlation, mutual information, KL, and negentropy reduce to combinations of
+entropies. This module offers three families that share the measures but differ in how the
+density is obtained.
+
+## Flow-based (Monte-Carlo) estimators
+
+Estimate a measure from a trained flow by sampling and scoring. Each takes the flow, a sample
+count `n_samples`, and a `key`; the estimate's variance shrinks as $O(1/\sqrt{N})$.
+
+::: gauss_flows.entropy
+
+::: gauss_flows.total_correlation
+
+::: gauss_flows.mutual_information
+
+::: gauss_flows.kl_divergence
+
+::: gauss_flows.negentropy
+
+## Analytical Gaussian closed forms
+
+Exact values for (multivariate) Gaussians — useful as ground truth in tests and as a baseline.
+For a covariance $\Sigma$ the differential entropy is
+$H = \tfrac12\log\!\big((2\pi e)^D\,|\Sigma|\big)$, and total correlation / mutual information
+follow from the log-determinant gap between the joint and its marginals.
+
+::: gauss_flows.gaussian_entropy
+
+::: gauss_flows.gaussian_total_correlation
+
+::: gauss_flows.gaussian_mutual_information
+
+::: gauss_flows.gaussian_kl_divergence
+
+## RBIG-way reductions
+
+The original RBIG estimators read a measure off the **total-correlation reduction** achieved by
+each Gaussianization layer, accumulated across the stack rather than scored from the final
+density. `information_reduction` is the per-pair building block; the others sum it along a
+fitted flow.
+
+::: gauss_flows.information_reduction
+
+::: gauss_flows.total_correlation_reduction
+
+::: gauss_flows.entropy_reduction
+
+::: gauss_flows.kl_divergence_reduction

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,3 +1,0 @@
-# API Reference
-
-::: gauss_flows

--- a/docs/api/surjections.md
+++ b/docs/api/surjections.md
@@ -1,0 +1,43 @@
+# Surjections & Stochastic transforms
+
+The [SurVAE](https://arxiv.org/abs/2007.02731) framework generalises a normalizing flow
+beyond exact bijections. A **surjection** is deterministic in one direction and
+stochastic (or many-to-one) in the other; a **stochastic** transform is random in both. Both
+relax the change-of-variables equality into a bound, contributing a *likelihood
+contribution* term in place of an exact `log_det`:
+
+$$
+\log p_X(x) \;\geq\; \mathbb{E}_{q(z\mid x)}\!\left[\log p_Z(z) + \mathcal{L}(x, z)\right],
+$$
+
+which is exact when the inverse direction is deterministic. This lets a flow change
+dimensionality (augment/slice, max-pool), encode invariances (abs, sort), or insert
+VAE-style stochastic layers — while still composing inside a `SurVAEFlow`.
+
+Surjection and stochastic methods take an explicit `key` (the direction may sample) and follow
+the **single-event** convention; the `SurVAEFlow` container vmaps `log_prob` / `sample` over
+any leading `sample_shape`.
+
+## Base classes
+
+::: gauss_flows.AbstractSurjection
+
+::: gauss_flows.AbstractStochastic
+
+## Surjections
+
+::: gauss_flows.SimpleAbsSurjection
+
+::: gauss_flows.SimpleSortSurjection
+
+::: gauss_flows.SimpleMaxPoolSurjection2d
+
+::: gauss_flows.Augment
+
+::: gauss_flows.Slice
+
+## Stochastic transforms
+
+::: gauss_flows.VAE
+
+::: gauss_flows.StochasticPermutation

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,14 +48,17 @@ from `gauss_flows` directly rather than the `_src/` paths.
 
 ## Installation
 
+Not yet on PyPI — install from source:
+
 ```bash
-uv add gauss_flows
+pip install git+https://github.com/jejjohnson/gauss_flows
 ```
 
-Or with pip:
+Or for development, clone and `uv sync`:
 
 ```bash
-pip install gauss_flows
+git clone https://github.com/jejjohnson/gauss_flows && cd gauss_flows
+uv sync --all-groups
 ```
 
 ## Quickstart
@@ -75,8 +78,23 @@ log_probs = flow.log_prob(samples)
 H = entropy(flow, n_samples=10_000, key=key)
 ```
 
+## What's inside
+
+- **[Bijections](api/bijections.md)** — coupling, marginal CDFs, linear/rotation,
+  normalisation, periodic, classic residual, and continuous (FFJORD) layers.
+- **[Surjections & Stochastic](api/surjections.md)** — dimension-changing surjections and
+  VAE-style stochastic transforms with lower-bound likelihoods.
+- **[Base Distributions](api/distributions.md)** — Gaussian mixtures, low-rank PCA Gaussian,
+  conditional diagonals, and sphere distributions.
+- **[Flows & RBIG](api/flows.md)** — `SurVAEFlow`, the `gaussianization_flow` /
+  `coupling_gaussianization_flow` / `iterative_rbig` factories, and the `fit_rbig` warm-start.
+- **[NumPyro Inference](api/inference.md)** — `FlowDist`, `FlowGuide`, and
+  `fit_gaussianization_flow`.
+- **[Information Theory](api/info_theory.md)** — entropy, total correlation, mutual
+  information, KL, and negentropy (Monte-Carlo, analytical, and RBIG-way).
+
 ## Links
 
-- [API Reference](api/reference.md)
-- [GitHub](https://github.com/jejjohnson/gauss_flows)
+- [API Reference](api/index.md)
 - [Changelog](https://github.com/jejjohnson/gauss_flows/blob/main/CHANGELOG.md)
+- [GitHub](https://github.com/jejjohnson/gauss_flows)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,18 @@ plugins:
           paths: [src]
           options:
             docstring_style: google
+            docstring_section_style: table
             show_source: true
             show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            heading_level: 3
+            show_signature_annotations: true
+            signature_crossrefs: true
+            merge_init_into_class: false
+            filters: ["!^_"]
   - mkdocs-jupyter:
       execute: false
       ignore_h1_titles: true
@@ -55,8 +65,16 @@ nav:
       - Conditional Flow Three Ways: notebooks/08_conditional_flow_three_ways.ipynb
       - Latent ODE on Spirals: notebooks/09_latent_ode_spirals.ipynb
       - Information-Theory Measures: notebooks/10_information_theory.ipynb
-  - API Reference: api/reference.md
+  - API Reference:
+      - Overview: api/index.md
+      - Bijections: api/bijections.md
+      - Surjections & Stochastic: api/surjections.md
+      - Base Distributions: api/distributions.md
+      - Flows & RBIG: api/flows.md
+      - NumPyro Inference: api/inference.md
+      - Information Theory: api/info_theory.md
   - Contributing: contributing.md
+  - Changelog: https://github.com/jejjohnson/gauss_flows/blob/main/CHANGELOG.md
 
 markdown_extensions:
   - admonition

--- a/src/gauss_flows/_src/conditioning.py
+++ b/src/gauss_flows/_src/conditioning.py
@@ -37,7 +37,7 @@ def pack_time_control(
 
     Example:
         >>> import jax.numpy as jnp
-        >>> from gauss_flows._src.conditioning import pack_time_control
+        >>> from gauss_flows import pack_time_control
         >>> pack_time_control(0.5).shape
         (1,)
         >>> pack_time_control(0.5, jnp.array([1.0, 2.0])).shape
@@ -75,7 +75,7 @@ def unpack_time_control(
 
     Example:
         >>> import jax.numpy as jnp
-        >>> from gauss_flows._src.conditioning import unpack_time_control
+        >>> from gauss_flows import unpack_time_control
         >>> t, control = unpack_time_control(jnp.array([0.5, 1.0, 2.0]), control_dim=2)
         >>> t.shape, control.shape
         ((1,), (2,))
@@ -109,7 +109,7 @@ def time_control_cond_shape(control_dim: int = 0) -> tuple[int, ...]:
         A one-tuple ``(1 + control_dim,)`` suitable for ``AbstractBijection``.
 
     Example:
-        >>> from gauss_flows._src.conditioning import time_control_cond_shape
+        >>> from gauss_flows import time_control_cond_shape
         >>> time_control_cond_shape()
         (1,)
         >>> time_control_cond_shape(3)

--- a/src/gauss_flows/_src/distributions/mixture.py
+++ b/src/gauss_flows/_src/distributions/mixture.py
@@ -5,6 +5,8 @@ provides a joint multi-modal base for Gaussianization pipelines on targets
 that are multi-modal or fat-tailed.
 """
 
+from __future__ import annotations
+
 from typing import ClassVar
 
 import equinox as eqx
@@ -19,27 +21,49 @@ from jaxtyping import PRNGKeyArray
 
 
 class GaussianMixture(AbstractDistribution):
-    """Trainable multivariate Gaussian Mixture Model base distribution.
+    """Trainable multivariate Gaussian-mixture base distribution.
 
     Parameterises a ``K``-component mixture of ``D``-dimensional Gaussians
-    with trainable component means, scales, and weights. Supports a
-    diagonal covariance parameterisation (scale per component per dim)
-    and a full-covariance Cholesky parameterisation.
+    with trainable component means, scales, and weights. The density is
+    ``p(x) = ∑ₖ wₖ · N(x; locₖ, Σₖ)`` with mixing weights ``w = softmax(
+    log_weights)``. Two covariance parameterisations are supported: a
+    diagonal one (one scale per component per dim) and a full-covariance
+    one (a per-component lower-triangular Cholesky factor).
+
+    Use as a flow base when the Gaussianized target is multi-modal or
+    fat-tailed — the natural companion to :class:`MixtureGaussianCDF`,
+    the per-dimension marginal transform.
 
     Args:
         key: JAX random key used to initialise the component means.
         n_components: Number of mixture components ``K``.
-        event_shape: Shape of a single sample ``(D,)``.
-        diagonal: If True (default), diagonal covariance via ``log_scale``.
-            If False, full covariance via a per-component lower-triangular
-            Cholesky factor.
-        loc_init_scale: Std of the Gaussian used to initialise component means.
+        event_shape: Shape of a single sample ``(D,)``. 1-D only.
+        diagonal: If ``True`` (default), diagonal covariance via
+            ``log_scale``. If ``False``, full covariance via a per-component
+            lower-triangular Cholesky factor. Defaults to ``True``.
+        loc_init_scale: Std of the Gaussian used to initialise component
+            means. Defaults to ``1.0``.
         log_scale_init: Initial value of ``log_scale`` (resp. Cholesky
             log-diagonal for ``diagonal=False``). Defaults to ``0.0``
             (unit scale at init).
 
-    The event shape is stored as ``self.shape`` per the flowjax
-    distribution contract. Uniform initial mixing weights.
+    Note:
+        The event shape is stored as ``self.shape`` per the flowjax
+        distribution contract; mixing weights are uniform at init.
+
+    Shape:
+        - log_prob: ``(D,)`` → scalar    (batch via vmap / leading axes)
+        - sample:   ``(key, sample_shape)`` → ``(*sample_shape, D)``
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import GaussianMixture
+        >>> dist = GaussianMixture(jr.key(0), n_components=3, event_shape=(2,))
+        >>> dist.sample(jr.key(1), (8,)).shape
+        (8, 2)
+        >>> dist.log_prob(jnp.zeros(2)).shape
+        ()
     """
 
     n_components: int = eqx.field(static=True)

--- a/src/gauss_flows/_src/distributions/pca.py
+++ b/src/gauss_flows/_src/distributions/pca.py
@@ -22,23 +22,50 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 
 
 class GaussianPCA(AbstractDistribution):
-    """Probabilistic-PCA Gaussian base distribution.
+    """Probabilistic-PCA Gaussian base distribution (low-rank + diagonal Σ).
 
-    ``x ~ N(loc, W W^T + sigma^2 I)`` with ``W in R^{D x K}``.
+    ``x ~ N(loc, Σ)`` with low-rank-plus-diagonal covariance
+    ``Σ = W Wᵀ + σ² I`` and ``W ∈ ℝ^{D × K}``. This costs only ``O(DK)``
+    parameters; sampling uses the reparametrisation ``x = loc + W z + σ ε``
+    (``z ∈ ℝ^K``, ``ε ∈ ℝ^D``), and ``log_prob`` applies the Woodbury
+    identity / matrix-determinant lemma so the inverse and log-determinant
+    cost ``O(K³) + O(DK)`` rather than ``O(D³)``.
+
+    Use as a flow base when the Gaussianized target has approximately
+    low-rank correlation structure in ``D`` dimensions.
 
     Args:
         key: JAX random key used to initialise ``W``.
-        event_shape: Shape of a single sample ``(D,)``.
-        latent_dim: Rank ``K``.
+        event_shape: Shape of a single sample ``(D,)``. 1-D only.
+        latent_dim: Rank ``K`` of the factor loading ``W`` (``1 ≤ K ≤ D``).
         loc: Mean vector. Scalar is broadcast to shape ``(D,)``.
-        log_sigma_init: Initial value of ``log(sigma)``.
+            Defaults to ``0.0``.
+        log_sigma_init: Initial value of ``log σ``. Defaults to ``0.0``.
         W_init_scale: Std of the Gaussian used to initialise ``W``.
-        eps: Numerical floor added to ``sigma^2`` so the Cholesky of the
-            ``K x K`` capacitance matrix stays well-defined and the
-            Woodbury quadratic stays finite even if ``log_sigma`` drifts
-            very negative during training. Default ``1e-12`` is far below
-            any reasonable target variance and does not affect gradients
-            in the well-conditioned regime.
+            Defaults to ``0.1``.
+        eps: Numerical floor added to ``σ²`` so the Cholesky of the
+            ``K × K`` capacitance matrix stays well-defined and the
+            Woodbury quadratic stays finite even if ``log σ`` drifts very
+            negative during training. Defaults to ``1e-12`` — far below any
+            reasonable target variance, with no effect on gradients in the
+            well-conditioned regime.
+
+    Shape:
+        - log_prob: ``(D,)`` → scalar    (batch via vmap / leading axes)
+        - sample:   ``(key, sample_shape)`` → ``(*sample_shape, D)``
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import GaussianPCA
+        >>> dist = GaussianPCA(jr.key(0), event_shape=(5,), latent_dim=2)
+        >>> dist.sample(jr.key(1), (8,)).shape
+        (8, 5)
+        >>> dist.log_prob(jnp.zeros(5)).shape
+        ()
+
+    References:
+        Tipping & Bishop 1999, *Probabilistic Principal Component Analysis*.
     """
 
     latent_dim: int = eqx.field(static=True)

--- a/src/gauss_flows/_src/distributions/sphere.py
+++ b/src/gauss_flows/_src/distributions/sphere.py
@@ -111,15 +111,20 @@ def _log_bessel_iv(nu: Array, x: Array) -> Array:
 
 
 class UniformOnSphere(AbstractDistribution):
-    """Uniform distribution on ``S^d ⊂ ℝ^{d+1}``.
+    """Uniform distribution on the unit sphere ``Sᵈ ⊂ ℝ^{d+1}``.
+
+    Constant density ``1 / A_d`` over the sphere, where ``A_d`` is the
+    surface area of ``Sᵈ``; ``log_prob`` returns ``−∞`` for off-sphere
+    points. Samples are drawn by normalising an isotropic Gaussian, so
+    they satisfy ``‖x‖₂ = 1`` up to numerical precision. Useful as a flow
+    base for directional / rotation-invariant data.
 
     Args:
         d: Intrinsic sphere dimension. Samples live in ``ℝ^{d+1}``.
 
     Shape:
-        Event shape: ``(d+1,)``.
-        Sample shape: arbitrary leading dimensions.
-        Samples satisfy ``||x||₂ = 1`` up to numerical precision.
+        - log_prob: ``(d+1,)`` → scalar    (batch via vmap / leading axes)
+        - sample:   ``(key, sample_shape)`` → ``(*sample_shape, d+1)``
 
     Example:
         >>> import jax.random as jr
@@ -153,22 +158,30 @@ class UniformOnSphere(AbstractDistribution):
 
 
 class VonMisesFisher(AbstractDistribution):
-    """Von Mises–Fisher distribution on ``S^d ⊂ ℝ^{d+1}``.
+    """Von Mises–Fisher distribution on the unit sphere ``Sᵈ ⊂ ℝ^{d+1}``.
 
-    Args:
-        mean: Mean direction in ``ℝ^{d+1}``. Normalized internally. Integer
-            inputs are promoted to a floating dtype.
-        concentration: Non-negative scalar concentration ``κ``.
-
-    Shape:
-        Event shape: ``(d+1,)`` where ``d = mean.shape[0] - 1``.
-        Sample shape: arbitrary leading dimensions.
-        ``log_prob`` is evaluated on single points on the sphere.
+    Density ``p(x) ∝ exp(κ · μᵀx)`` on the sphere: the spherical analogue of
+    an isotropic Gaussian, peaked at the mean direction ``μ`` with
+    concentration ``κ`` (``κ = 0`` recovers :class:`UniformOnSphere`). The
+    normaliser involves a modified Bessel function ``I_ν(κ)``, evaluated
+    here via a hybrid power-series / asymptotic expansion. Sampling uses
+    Wood's (1994) rejection scheme. Useful as a flow base for concentrated
+    directional data.
 
     Invalid inputs (zero-vector ``mean`` or negative ``concentration``) are
     propagated as ``NaN`` through ``log_prob`` / ``sample`` rather than being
-    rejected at construction, so the constructor stays ``jit``/``vmap``-safe
-    (e.g. for a mixture of VMFs).
+    rejected at construction, so the constructor stays ``jit`` / ``vmap``-safe
+    (e.g. inside a mixture of VMFs).
+
+    Args:
+        mean: Mean direction ``μ`` in ``ℝ^{d+1}``. Normalised internally;
+            integer inputs are promoted to a floating dtype. Sets the event
+            dimension ``d = mean.shape[0] − 1``.
+        concentration: Non-negative scalar concentration ``κ``.
+
+    Shape:
+        - log_prob: ``(d+1,)`` → scalar    (batch via vmap / leading axes)
+        - sample:   ``(key, sample_shape)`` → ``(*sample_shape, d+1)``
 
     Example:
         >>> import jax.numpy as jnp

--- a/src/gauss_flows/_src/flows/gaussianization.py
+++ b/src/gauss_flows/_src/flows/gaussianization.py
@@ -32,8 +32,14 @@ def gaussianization_flow(
 ) -> Transformed:
     """Construct a Gaussianization flow.
 
-    Each layer consists of a marginal Gaussianization step (using a mixture of
-    Gaussians CDF) followed by a rotation (Householder or orthogonal).
+    Stacks ``n_layers`` alternating G∘R blocks, where each block is a
+    marginal Gaussianization step G (a mixture-of-Gaussians CDF applied
+    per dimension) followed by a rotation R (Householder, orthogonal, or
+    LU-parametrised linear). Mixture means and Householder vectors are
+    randomly initialised to break symmetry so gradient training has a
+    signal to separate the components. The block stack is composed with a
+    memory-efficient :class:`flowjax.bijections.Scan` and wrapped in a
+    base :class:`~flowjax.distributions.Normal`.
 
     Args:
         key: JAX random key.
@@ -43,14 +49,26 @@ def gaussianization_flow(
             Defaults to 8.
         rotation: Type of rotation, one of ``"householder"``, ``"orthogonal"``,
             or ``"lu"`` (LU-parametrised linear + reverse permutation).
-            Defaults to "householder".
-        n_reflections: Number of Householder reflections (only for "householder").
-            Defaults to n_dims.
+            Defaults to ``"householder"``.
+        n_reflections: Number of Householder reflections (only for
+            ``"householder"``). Defaults to ``n_dims``.
         base_dist: Optional base distribution override (must have event
-            shape ``(n_dims,)``). Defaults to a standard ``Normal``.
+            shape ``(n_dims,)`` and be unconditional). Defaults to a standard
+            ``Normal``.
 
     Returns:
-        A flowjax Transformed distribution.
+        A flowjax ``Transformed`` distribution with ``log_prob`` and ``sample``.
+
+    Raises:
+        ValueError: If ``base_dist`` has the wrong event shape, is
+            conditional, or ``rotation`` is not a recognised name.
+
+    Example:
+        >>> import jax.random as jr
+        >>> from gauss_flows import gaussianization_flow
+        >>> flow = gaussianization_flow(jr.key(0), n_dims=4, n_layers=4, n_components=8)
+        >>> flow.sample(jr.key(1), (8,)).shape
+        (8, 4)
     """
     if n_reflections is None:
         n_reflections = n_dims
@@ -116,8 +134,15 @@ def coupling_gaussianization_flow(
 ) -> Transformed:
     """Construct a coupling-based Gaussianization flow.
 
-    Uses rational quadratic spline coupling layers interleaved with
-    permutations. Each layer can represent complex non-linear transformations.
+    Stacks ``n_layers`` alternating C∘P blocks, where each block is a
+    rational-quadratic-spline coupling layer C followed by a permutation P
+    (a :class:`~flowjax.bijections.Flip` for ``n_dims == 2``, a random
+    :class:`~flowjax.bijections.Permute` otherwise; no permutation for
+    ``n_dims == 1``). Unlike :func:`gaussianization_flow`, the coupling
+    conditioner lets each layer represent non-linear, cross-coordinate
+    transformations. The block stack is composed with
+    :class:`flowjax.bijections.Scan` and wrapped in a base
+    :class:`~flowjax.distributions.Normal`.
 
     Args:
         key: JAX random key.
@@ -127,10 +152,18 @@ def coupling_gaussianization_flow(
         nn_width: Hidden layer width for coupling conditioner. Defaults to 64.
         nn_depth: Depth of the coupling conditioner MLP. Defaults to 2.
         interval: Interval for the rational quadratic spline. Defaults to 5.0.
-        invert: Whether to invert the bijection for faster log_prob. Defaults to True.
+        invert: Whether to invert the bijection so ``log_prob`` runs in the
+            fast direction. Defaults to True.
 
     Returns:
-        A flowjax Transformed distribution.
+        A flowjax ``Transformed`` distribution with ``log_prob`` and ``sample``.
+
+    Example:
+        >>> import jax.random as jr
+        >>> from gauss_flows import coupling_gaussianization_flow
+        >>> flow = coupling_gaussianization_flow(jr.key(0), n_dims=4, n_layers=2)
+        >>> flow.sample(jr.key(1), (8,)).shape
+        (8, 4)
     """
     shape = (n_dims,)
     base_dist = Normal(jnp.zeros(n_dims))

--- a/src/gauss_flows/_src/flows/rbig.py
+++ b/src/gauss_flows/_src/flows/rbig.py
@@ -19,8 +19,12 @@ def iterative_rbig(
 ) -> Transformed:
     """Construct an iterative RBIG (Rotation-Based Iterative Gaussianization) flow.
 
-    This implements the classic RBIG algorithm as a normalizing flow, alternating
-    between marginal Gaussianization and rotation at each iteration.
+    Implements the classic RBIG algorithm as a normalizing flow: each of
+    ``n_layers`` iterations alternates a marginal Gaussianization step G
+    with a rotation R (the G∘R block). This is a thin wrapper around
+    :func:`~gauss_flows.gaussianization_flow` with a large default
+    ``n_layers`` reflecting the many shallow iterations RBIG typically
+    uses; all arguments are forwarded unchanged.
 
     Args:
         key: JAX random key.
@@ -28,12 +32,19 @@ def iterative_rbig(
         n_layers: Number of RBIG iterations. Defaults to 100.
         n_components: Number of mixture components for marginal Gaussianization.
             Defaults to 8.
-        rotation: Type of rotation, either "householder" or "orthogonal".
-            Defaults to "householder".
-        n_reflections: Number of Householder reflections. Defaults to n_dims.
+        rotation: Type of rotation, either ``"householder"`` or
+            ``"orthogonal"``. Defaults to ``"householder"``.
+        n_reflections: Number of Householder reflections. Defaults to ``n_dims``.
 
     Returns:
-        A flowjax Transformed distribution.
+        A flowjax ``Transformed`` distribution with ``log_prob`` and ``sample``.
+
+    Example:
+        >>> import jax.random as jr
+        >>> from gauss_flows import iterative_rbig
+        >>> flow = iterative_rbig(jr.key(0), n_dims=4, n_layers=3, n_components=4)
+        >>> flow.sample(jr.key(1), (5,)).shape
+        (5, 4)
     """
     return gaussianization_flow(
         key,

--- a/src/gauss_flows/_src/flows/survae.py
+++ b/src/gauss_flows/_src/flows/survae.py
@@ -108,6 +108,27 @@ class SurVAEFlow(eqx.Module):
         the whole point of coupling) and the *external* ``condition``
         (present only when ``cond_dim > 0``). The two are concatenated
         inside the inner MLP; users do not slice or merge them manually.
+
+    Shape:
+        Methods follow the single-event convention but accept a leading
+        ``sample_shape`` that is vmapped over internally:
+
+        - ``sample(key, sample_shape, condition)`` → ``sample_shape + data_shape``
+        - ``log_prob(x, key, condition)``: ``x`` of shape
+          ``sample_shape + data_shape`` → ``sample_shape``
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from flowjax.distributions import Normal
+        >>> from gauss_flows import SurVAEFlow, AffineCoupling
+        >>> base = Normal(jnp.zeros(4))
+        >>> flow = SurVAEFlow(base, [AffineCoupling(jr.key(0), shape=(4,))])
+        >>> x = flow.sample(jr.key(1), (5,))
+        >>> x.shape
+        (5, 4)
+        >>> flow.log_prob(x, jr.key(2)).shape
+        (5,)
     """
 
     base_dist: AbstractDistribution

--- a/src/gauss_flows/_src/inference/numpyro_compat.py
+++ b/src/gauss_flows/_src/inference/numpyro_compat.py
@@ -14,25 +14,33 @@ from jaxtyping import PRNGKeyArray
 
 
 class FlowDist(dist_lib.Distribution):
-    """Wraps a flowjax Transformed distribution as a NumPyro distribution.
+    """Wrap a flowjax ``Transformed`` distribution as a NumPyro distribution.
 
-    This allows Gaussianization flows (and other flowjax distributions) to be
-    used directly in NumPyro probabilistic programs with standard MCMC
-    or variational inference algorithms.
+    Subclasses :class:`numpyro.distributions.Distribution`, delegating
+    ``sample`` and ``log_prob`` to the wrapped flow. This lets
+    Gaussianization flows (and other flowjax distributions) be used
+    directly in NumPyro probabilistic programs with standard MCMC or
+    variational inference algorithms. The batch shape is empty and the
+    event shape is taken from ``flow.shape``; the support is a real
+    vector.
 
     Args:
-        flow: A flowjax Transformed distribution.
+        flow: A flowjax ``Transformed`` distribution.
 
     Example:
         >>> import jax.random as jr
-        >>> import numpyro
-        >>> import numpyro.distributions as dist
         >>> from gauss_flows import gaussianization_flow, FlowDist
-        >>> key = jr.key(0)
-        >>> flow = gaussianization_flow(key, n_dims=2)
+        >>> flow = gaussianization_flow(jr.key(0), n_dims=2)
         >>> flow_dist = FlowDist(flow)
-        >>> # Use in a NumPyro model:
-        >>> # numpyro.sample("x", flow_dist)
+        >>> flow_dist.event_shape
+        (2,)
+        >>> x = flow_dist.sample(jr.key(1), (5,))
+        >>> x.shape
+        (5, 2)
+        >>> flow_dist.log_prob(x).shape
+        (5,)
+
+        Use inside a NumPyro model with ``numpyro.sample("x", flow_dist)``.
     """
 
     arg_constraints: ClassVar[dict] = {}
@@ -49,10 +57,10 @@ class FlowDist(dist_lib.Distribution):
 
         Args:
             key: JAX random key.
-            sample_shape: Shape of samples to draw. Defaults to ().
+            sample_shape: Shape of samples to draw. Defaults to ``()``.
 
         Returns:
-            Samples of shape sample_shape + event_shape.
+            Samples of shape ``sample_shape + event_shape``.
         """
         return self.flow.sample(key, sample_shape)
 
@@ -60,10 +68,11 @@ class FlowDist(dist_lib.Distribution):
         """Compute log probability under the flow.
 
         Args:
-            value: Points at which to evaluate the log probability.
+            value: Points of shape ``sample_shape + event_shape`` at which
+                to evaluate the log probability.
 
         Returns:
-            Log probability values.
+            Log-probability values of shape ``sample_shape``.
         """
         return self.flow.log_prob(value)
 

--- a/src/gauss_flows/_src/inference/numpyro_guide.py
+++ b/src/gauss_flows/_src/inference/numpyro_guide.py
@@ -4,8 +4,15 @@ Provides :class:`FlowGuide`, a variational guide that uses a normalizing flow
 as the approximate posterior for Stochastic Variational Inference (SVI).
 """
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
 import jax.random as jr
+from flowjax.distributions import Transformed
 from flowjax.experimental.numpyro import register_params
+from jaxtyping import PRNGKeyArray
 from numpyro.infer.autoguide import AutoContinuous
 from numpyro.infer.initialization import init_to_uniform
 
@@ -16,10 +23,13 @@ from gauss_flows._src.inference.numpyro_compat import FlowDist
 class FlowGuide(AutoContinuous):
     """NumPyro variational guide using a Gaussianization flow.
 
-    Uses a normalizing flow as the variational distribution for SVI,
-    modelling a joint distribution over the concatenated unconstrained
-    latent space of the model.  The flow captures cross-variable
-    correlations because all latent sites are handled jointly.
+    Subclasses :class:`numpyro.infer.autoguide.AutoContinuous`, using a
+    normalizing flow as the variational distribution for SVI. The flow
+    models a joint distribution over the concatenated unconstrained latent
+    space of the model, so it captures cross-variable correlations because
+    all latent sites are handled jointly. The flow is built lazily once
+    ``latent_dim`` is known (at prototype setup), and its parameters are
+    registered with NumPyro so the SVI optimiser can update them.
 
     Args:
         model: A NumPyro model.
@@ -59,13 +69,13 @@ class FlowGuide(AutoContinuous):
 
     def __init__(
         self,
-        model,
+        model: Callable[..., Any],
         *,
-        flow_factory=gaussianization_flow,
-        flow_kwargs=None,
-        init_key=None,
-        prefix="auto",
-        init_loc_fn=init_to_uniform,
+        flow_factory: Callable[..., Transformed] = gaussianization_flow,
+        flow_kwargs: dict[str, Any] | None = None,
+        init_key: PRNGKeyArray | None = None,
+        prefix: str = "auto",
+        init_loc_fn: Callable[..., Any] = init_to_uniform,
     ):
         self._flow_factory = flow_factory
         self._flow_kwargs = flow_kwargs if flow_kwargs is not None else {}

--- a/src/gauss_flows/_src/inference/train.py
+++ b/src/gauss_flows/_src/inference/train.py
@@ -1,5 +1,7 @@
 """Training utilities for Gaussianization flows."""
 
+from __future__ import annotations
+
 from flowjax.distributions import AbstractDistribution
 from flowjax.train.loops import fit_to_data
 from jaxtyping import ArrayLike, PRNGKeyArray
@@ -16,16 +18,19 @@ def fit_gaussianization_flow(
     batch_size: int = 256,
     val_prop: float = 0.1,
     show_progress: bool = True,
-):
-    """Fit a Gaussianization flow to data using maximum likelihood.
+) -> tuple[AbstractDistribution, dict[str, list[float]]]:
+    """Fit a Gaussianization flow to data by maximum likelihood.
 
-    Wraps ``flowjax.train.fit_to_data`` with sensible defaults for
-    Gaussianization flows.
+    Thin wrapper around :func:`flowjax.train.fit_to_data` with sensible
+    defaults for Gaussianization flows. Minimises the negative
+    log-likelihood with Adam and early stopping on a held-out validation
+    split, returning the best-performing parameters.
 
     Args:
         key: JAX random key.
-        dist: A flowjax distribution (e.g. from ``gaussianization_flow``).
-        data: Training data array of shape (n_samples, n_dims).
+        dist: A flowjax distribution (e.g. from
+            :func:`~gauss_flows.gaussianization_flow`).
+        data: Training data array of shape ``(n_samples, n_dims)``.
         learning_rate: Adam optimizer learning rate. Defaults to 5e-4.
         max_epochs: Maximum training epochs. Defaults to 100.
         max_patience: Early stopping patience in epochs. Defaults to 5.
@@ -34,8 +39,21 @@ def fit_gaussianization_flow(
         show_progress: Whether to show a progress bar. Defaults to True.
 
     Returns:
-        Tuple of (trained_dist, losses) where losses is a dict with "train" and
-        "val" lists of per-epoch losses.
+        A tuple ``(trained_dist, losses)`` where ``trained_dist`` is the
+        fitted flow and ``losses`` is a dict with ``"train"`` and ``"val"``
+        lists of per-epoch losses.
+
+    Example:
+        .. code-block:: python
+
+            import jax.random as jr
+            from gauss_flows import gaussianization_flow, fit_gaussianization_flow
+
+            data = jr.normal(jr.key(0), (1024, 2))
+            flow = gaussianization_flow(jr.key(1), n_dims=2, n_layers=2)
+            trained, losses = fit_gaussianization_flow(
+                jr.key(2), flow, data, max_epochs=5, show_progress=False
+            )
     """
     return fit_to_data(
         key,

--- a/src/gauss_flows/_src/info_theory.py
+++ b/src/gauss_flows/_src/info_theory.py
@@ -1,15 +1,22 @@
-"""Information-theoretic measures using normalizing flows.
+"""Information-theoretic measures for normalizing flows.
 
-These functions compute various IT measures in three complementary ways:
+Three complementary families of estimators are provided, each measuring the
+same quantities (entropy, total correlation, mutual information, KL divergence,
+negentropy) but under different assumptions. All entropies and divergences are
+returned in **nats** (natural logarithm).
 
-* **Analytical** closed forms for multivariate Gaussians
-  (:func:`gaussian_entropy`, :func:`gaussian_total_correlation`,
-  :func:`gaussian_mutual_information`, :func:`gaussian_kl_divergence`).
-* **Change-of-variables** Monte-Carlo estimators that exploit the exact
-  log-density of a fitted flow (:func:`entropy`, :func:`total_correlation`,
+* **Flow-based Monte-Carlo** estimators draw ``n_samples`` from a *trained*
+  flow and average its exact change-of-variables log-density. They require a
+  ``key`` and converge as O(1/√N) (:func:`entropy`, :func:`total_correlation`,
   :func:`mutual_information`, :func:`kl_divergence`, :func:`negentropy`).
-* **RBIG-way** estimators that accumulate the total-correlation removed by a
-  Gaussianization flow (:func:`information_reduction`,
+* **Analytical Gaussian** closed forms evaluate the exact expression for a
+  multivariate Gaussian from its covariance (and mean). They are deterministic
+  and take no samples (:func:`gaussian_entropy`,
+  :func:`gaussian_total_correlation`, :func:`gaussian_mutual_information`,
+  :func:`gaussian_kl_divergence`).
+* **RBIG-way reductions** accumulate the total correlation removed by a
+  Gaussianization flow, pairing histogram marginal entropies with a Gaussian
+  joint entropy (:func:`information_reduction`,
   :func:`total_correlation_reduction`, :func:`entropy_reduction`,
   :func:`kl_divergence_reduction`).
 """
@@ -20,22 +27,36 @@ import jax
 import jax.numpy as jnp
 from flowjax.distributions import AbstractDistribution
 from jax import Array
-from jaxtyping import ArrayLike
+from jaxtyping import ArrayLike, PRNGKeyArray
 
 
-def entropy(dist: AbstractDistribution, n_samples: int = 10000, *, key) -> Array:
-    """Estimate the differential entropy of a distribution.
+def entropy(
+    dist: AbstractDistribution, n_samples: int = 10000, *, key: PRNGKeyArray
+) -> Array:
+    """Differential entropy of a flow (flow-based Monte-Carlo estimator).
 
-    Uses Monte Carlo estimation: H(X) = -E[log p(X)] where samples are drawn
-    from the distribution.
+    Draws samples from the trained ``dist`` and averages its exact log-density::
+
+        H(X) = −E[log p(X)] ≈ −(1/N) Σᵢ log p(xᵢ),   xᵢ ∼ dist.
+
+    The estimate converges as O(1/√N) in ``n_samples``.
 
     Args:
-        dist: A flowjax distribution.
-        n_samples: Number of Monte Carlo samples. Defaults to 10000.
-        key: JAX random key.
+        dist: A trained flowjax distribution exposing ``sample`` and
+            ``log_prob``.
+        n_samples: Number of Monte-Carlo samples. Defaults to 10000.
+        key: JAX PRNG key used to draw the samples.
 
     Returns:
-        Scalar estimate of the differential entropy.
+        Scalar differential-entropy estimate (in nats).
+
+    Example:
+        Requires a fitted flow, so the call is slow and non-deterministic::
+
+            import jax.random as jr
+            from gauss_flows import entropy
+
+            h = entropy(trained_flow, n_samples=10000, key=jr.key(0))
     """
     samples = dist.sample(key, (n_samples,))
     log_probs = dist.log_prob(samples)
@@ -43,21 +64,34 @@ def entropy(dist: AbstractDistribution, n_samples: int = 10000, *, key) -> Array
 
 
 def total_correlation(
-    dist: AbstractDistribution, n_samples: int = 10000, *, key
+    dist: AbstractDistribution, n_samples: int = 10000, *, key: PRNGKeyArray
 ) -> Array:
-    """Estimate the total correlation (multi-information) of a distribution.
+    """Total correlation of a flow (flow-based Monte-Carlo estimator).
 
-    Total correlation is defined as:
-        TC(X) = sum_i H(X_i) - H(X)
-    where H(X_i) is the marginal entropy of each dimension.
+    Total correlation (multi-information) is the gap between the sum of marginal
+    entropies and the joint entropy::
+
+        TC(X) = Σᵢ H(Xᵢ) − H(X).
+
+    Samples are drawn from the trained ``dist``; the joint entropy is the
+    Monte-Carlo average −(1/N) Σ log p(xᵢ), while each marginal entropy uses a
+    Gaussian fitted to the corresponding sample column. Converges as O(1/√N).
 
     Args:
-        dist: A flowjax distribution with 1D shape.
-        n_samples: Number of Monte Carlo samples. Defaults to 10000.
-        key: JAX random key.
+        dist: A trained flowjax distribution with a 1-D event shape.
+        n_samples: Number of Monte-Carlo samples. Defaults to 10000.
+        key: JAX PRNG key used to draw the samples.
 
     Returns:
-        Scalar estimate of total correlation (in nats).
+        Scalar total-correlation estimate (in nats).
+
+    Example:
+        Requires a fitted flow, so the call is slow and non-deterministic::
+
+            import jax.random as jr
+            from gauss_flows import total_correlation
+
+            tc = total_correlation(trained_flow, n_samples=10000, key=jr.key(0))
     """
     import jax.random as jr
 
@@ -88,21 +122,36 @@ def mutual_information(
     dist_y: AbstractDistribution,
     n_samples: int = 10000,
     *,
-    key,
+    key: PRNGKeyArray,
 ) -> Array:
-    """Estimate the mutual information I(X; Y).
+    """Mutual information I(X; Y) of flows (flow-based Monte-Carlo estimator).
 
-    I(X; Y) = H(X) + H(Y) - H(X, Y)
+    Combines three Monte-Carlo entropy estimates of the supplied trained
+    flows::
+
+        I(X; Y) = H(X) + H(Y) − H(X, Y).
+
+    Each entropy is estimated via :func:`entropy` from independent sample
+    batches, so the result converges as O(1/√N).
 
     Args:
-        dist_xy: Joint distribution of (X, Y).
-        dist_x: Marginal distribution of X.
-        dist_y: Marginal distribution of Y.
-        n_samples: Number of Monte Carlo samples. Defaults to 10000.
-        key: JAX random key.
+        dist_xy: Trained joint distribution of (X, Y).
+        dist_x: Trained marginal distribution of X.
+        dist_y: Trained marginal distribution of Y.
+        n_samples: Number of Monte-Carlo samples per entropy term.
+            Defaults to 10000.
+        key: JAX PRNG key; split three ways for the three entropy estimates.
 
     Returns:
-        Scalar estimate of mutual information.
+        Scalar mutual-information estimate (in nats).
+
+    Example:
+        Requires fitted flows, so the call is slow and non-deterministic::
+
+            import jax.random as jr
+            from gauss_flows import mutual_information
+
+            mi = mutual_information(flow_xy, flow_x, flow_y, key=jr.key(0))
     """
     import jax.random as jr
 
@@ -118,20 +167,34 @@ def kl_divergence(
     dist_q: AbstractDistribution,
     n_samples: int = 10000,
     *,
-    key,
+    key: PRNGKeyArray,
 ) -> Array:
-    """Estimate the KL divergence KL(P || Q) using Monte Carlo.
+    """KL divergence KL(P ‖ Q) of flows (flow-based Monte-Carlo estimator).
 
-    KL(P || Q) = E_P[log p(X) - log q(X)]
+    Samples are drawn from ``dist_p`` and both flows' exact log-densities are
+    averaged::
+
+        KL(P ‖ Q) = E_P[log p(X) − log q(X)]
+                  ≈ (1/N) Σᵢ [log p(xᵢ) − log q(xᵢ)],   xᵢ ∼ dist_p.
+
+    Converges as O(1/√N) in ``n_samples``.
 
     Args:
-        dist_p: Distribution P (samples are drawn from this).
-        dist_q: Distribution Q (log-probs are evaluated under this).
-        n_samples: Number of Monte Carlo samples. Defaults to 10000.
-        key: JAX random key.
+        dist_p: Trained distribution P; samples are drawn from this.
+        dist_q: Trained distribution Q; log-probs are evaluated under this.
+        n_samples: Number of Monte-Carlo samples. Defaults to 10000.
+        key: JAX PRNG key used to draw the samples from P.
 
     Returns:
-        Scalar estimate of the KL divergence.
+        Scalar KL-divergence estimate (in nats).
+
+    Example:
+        Requires fitted flows, so the call is slow and non-deterministic::
+
+            import jax.random as jr
+            from gauss_flows import kl_divergence
+
+            kl = kl_divergence(flow_p, flow_q, n_samples=10000, key=jr.key(0))
     """
     samples = dist_p.sample(key, (n_samples,))
     log_p = dist_p.log_prob(samples)
@@ -139,20 +202,35 @@ def kl_divergence(
     return jnp.mean(log_p - log_q)
 
 
-def negentropy(dist: AbstractDistribution, n_samples: int = 10000, *, key) -> Array:
-    """Estimate the negentropy of a distribution.
+def negentropy(
+    dist: AbstractDistribution, n_samples: int = 10000, *, key: PRNGKeyArray
+) -> Array:
+    """Negentropy of a flow (flow-based Monte-Carlo estimator).
 
-    Negentropy is defined as:
-        J(X) = H(X_gauss) - H(X)
-    where X_gauss is a Gaussian with the same mean and variance as X.
+    Negentropy is the entropy gap to the Gaussian of matched moments — a
+    non-negative measure of non-Gaussianity::
+
+        J(X) = H(X_gauss) − H(X),
+
+    where ``X_gauss`` is the Normal sharing the per-dimension mean and standard
+    deviation of the samples drawn from ``dist``. Both entropies are estimated
+    via :func:`entropy`, so the result converges as O(1/√N).
 
     Args:
-        dist: A flowjax distribution.
-        n_samples: Number of Monte Carlo samples. Defaults to 10000.
-        key: JAX random key.
+        dist: A trained flowjax distribution.
+        n_samples: Number of Monte-Carlo samples. Defaults to 10000.
+        key: JAX PRNG key used to draw the samples and estimate both entropies.
 
     Returns:
-        Scalar estimate of negentropy.
+        Scalar negentropy estimate (in nats).
+
+    Example:
+        Requires a fitted flow, so the call is slow and non-deterministic::
+
+            import jax.random as jr
+            from gauss_flows import negentropy
+
+            j = negentropy(trained_flow, n_samples=10000, key=jr.key(0))
     """
     import jax.random as jr
     from flowjax.distributions import Normal
@@ -178,15 +256,23 @@ def negentropy(dist: AbstractDistribution, n_samples: int = 10000, *, key) -> Ar
 
 
 def gaussian_entropy(covariance: ArrayLike) -> Array:
-    """Differential entropy of a multivariate Gaussian (analytical).
+    """Differential entropy of a Gaussian (analytical Gaussian closed form).
 
-    H(X) = 1/2 log |2 pi e Sigma|
+    Deterministic, sample-free closed form in the covariance::
+
+        H(X) = ½ log |2π e Σ| = ½ (d log(2π e) + log|Σ|).
 
     Args:
-        covariance: Covariance matrix Sigma of shape ``(d, d)``.
+        covariance: Covariance matrix Σ of shape ``(d, d)``.
 
     Returns:
-        Scalar differential entropy in nats.
+        Scalar differential entropy (in nats).
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import gaussian_entropy
+        >>> round(float(gaussian_entropy(jnp.eye(3))), 4)
+        4.2568
     """
     cov = jnp.asarray(covariance)
     d = cov.shape[-1]
@@ -195,15 +281,29 @@ def gaussian_entropy(covariance: ArrayLike) -> Array:
 
 
 def gaussian_total_correlation(covariance: ArrayLike) -> Array:
-    """Total correlation of a multivariate Gaussian (analytical).
+    """Total correlation of a Gaussian (analytical Gaussian closed form).
 
-    TC(X) = 1/2 [ sum_i log Sigma_ii - log |Sigma| ]
+    Deterministic, sample-free closed form comparing the diagonal variances to
+    the full covariance::
+
+        TC(X) = ½ [ Σᵢ log Σᵢᵢ − log|Σ| ].
+
+    It is zero exactly when Σ is diagonal (independent components).
 
     Args:
-        covariance: Covariance matrix Sigma of shape ``(d, d)``.
+        covariance: Covariance matrix Σ of shape ``(d, d)``.
 
     Returns:
-        Scalar total correlation in nats.
+        Scalar total correlation (in nats).
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import gaussian_total_correlation
+        >>> cov = jnp.array([[1.0, 0.5], [0.5, 1.0]])
+        >>> round(float(gaussian_total_correlation(cov)), 4)
+        0.1438
+        >>> float(gaussian_total_correlation(jnp.eye(2)))  # diagonal → 0
+        0.0
     """
     cov = jnp.asarray(covariance)
     variances = jnp.diagonal(cov)
@@ -212,17 +312,28 @@ def gaussian_total_correlation(covariance: ArrayLike) -> Array:
 
 
 def gaussian_mutual_information(covariance: ArrayLike, dim_x: int) -> Array:
-    """Mutual information between two Gaussian blocks X and Y (analytical).
+    """Mutual information of Gaussian blocks (analytical Gaussian closed form).
 
-    I(X; Y) = H(X) + H(Y) - H(X, Y), where the joint covariance is partitioned
-    into the leading ``dim_x`` dimensions (X) and the rest (Y).
+    Deterministic, sample-free closed form. The joint covariance is partitioned
+    into the leading ``dim_x`` dimensions (X) and the remainder (Y), then::
+
+        I(X; Y) = H(X) + H(Y) − H(X, Y),
+
+    each entropy evaluated via :func:`gaussian_entropy`.
 
     Args:
         covariance: Joint covariance matrix of ``[X, Y]`` of shape ``(d, d)``.
         dim_x: Number of leading dimensions belonging to X.
 
     Returns:
-        Scalar mutual information in nats.
+        Scalar mutual information (in nats).
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import gaussian_mutual_information
+        >>> cov = jnp.array([[1.0, 0.5], [0.5, 1.0]])
+        >>> round(float(gaussian_mutual_information(cov, dim_x=1)), 4)
+        0.1438
     """
     cov = jnp.asarray(covariance)
     cov_xx = cov[:dim_x, :dim_x]
@@ -236,11 +347,15 @@ def gaussian_kl_divergence(
     mean_q: ArrayLike,
     cov_q: ArrayLike,
 ) -> Array:
-    """KL divergence between two multivariate Gaussians (analytical).
+    """KL divergence of two Gaussians (analytical Gaussian closed form).
 
-    KL(N_p || N_q) = 1/2 [ tr(Sigma_q^-1 Sigma_p)
-        + (mu_q - mu_p)^T Sigma_q^-1 (mu_q - mu_p) - d
-        + log(|Sigma_q| / |Sigma_p|) ]
+    Deterministic, sample-free closed form::
+
+        KL(N_p ‖ N_q) = ½ [ tr(Σ_q⁻¹ Σ_p)
+                            + (μ_q − μ_p)ᵀ Σ_q⁻¹ (μ_q − μ_p) − d
+                            + log(|Σ_q| / |Σ_p|) ].
+
+    It is zero exactly when the two Gaussians coincide.
 
     Args:
         mean_p: Mean of P, shape ``(d,)``.
@@ -249,7 +364,14 @@ def gaussian_kl_divergence(
         cov_q: Covariance of Q, shape ``(d, d)``.
 
     Returns:
-        Scalar KL divergence in nats.
+        Scalar KL divergence (in nats).
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import gaussian_kl_divergence
+        >>> mu, eye = jnp.zeros(2), jnp.eye(2)
+        >>> float(gaussian_kl_divergence(mu, eye, mu, eye))  # identical → 0
+        0.0
     """
     mu_p = jnp.asarray(mean_p)
     mu_q = jnp.asarray(mean_q)
@@ -346,24 +468,31 @@ def _total_correlation_estimate(x: Array, n_bins: int) -> Array:
 def information_reduction(
     x_before: ArrayLike, x_after: ArrayLike, *, n_bins: int | None = None
 ) -> Array:
-    """Total-correlation removed between two representations of the data.
+    """Total correlation removed between two representations (RBIG-way reduction).
 
-    This is the building block of the "RBIG-way" estimators. The reduction is
-    the drop in total correlation when moving from ``x_before`` to ``x_after``::
+    The building block of the RBIG-way estimators: the drop in total
+    correlation when moving from ``x_before`` to ``x_after``::
 
-        Delta_TC = TC(x_before) - TC(x_after)
+        Δ_TC = TC(x_before) − TC(x_after),
 
-    with ``TC(X) = sum_i H(X_i) - H(X)``, marginal entropies estimated from
+    with ``TC(X) = Σᵢ H(Xᵢ) − H(X)``, marginal entropies estimated from
     histograms and the joint entropy from the Gaussian (maximum-entropy)
     approximation.
 
     Args:
         x_before: Data before the transformation, shape ``(n, d)``.
         x_after: Data after the transformation, shape ``(n, d)``.
-        n_bins: Histogram bins per marginal. Defaults to ``round(sqrt(n))``.
+        n_bins: Histogram bins per marginal. Defaults to ``round(√n)``.
 
     Returns:
-        Scalar total-correlation reduction in nats.
+        Scalar total-correlation reduction (in nats).
+
+    Example:
+        Plain sampled data, no flow required::
+
+            from gauss_flows import information_reduction
+
+            delta_tc = information_reduction(x_before, x_after)
     """
     xb = jnp.asarray(x_before)
     xa = jnp.asarray(x_after)

--- a/src/gauss_flows/_src/init/rbig.py
+++ b/src/gauss_flows/_src/init/rbig.py
@@ -118,14 +118,17 @@ def fit_rbig(
     n_components: int = 8,
     random_state: int = 0,
 ) -> Transformed:
-    """Fit an iterative-Gaussianization (RBIG) flow to data.
+    """Fit an iterative-Gaussianization (RBIG) flow to data in closed form.
 
     Greedily walks ``n_layers`` blocks of ``[FixedRotation (PCA),
-    MixtureGaussianCDF (GMM per-dim)]``, fitting each from the current
-    state and propagating the data forward before the next block. The
-    result is a :class:`flowjax.distributions.Transformed` whose
-    ``log_prob`` is already a reasonable density estimator before any
-    gradient training.
+    MixtureGaussianCDF (GMM per-dim)]``, fitting each block directly from
+    the current data state — a per-dimension sklearn ``GaussianMixture``
+    EM fit, no gradient training — and propagating the data forward
+    before the next block. The result is a warm start: a
+    :class:`flowjax.distributions.Transformed` whose ``log_prob`` is
+    already a reasonable density estimator and can be refined further by
+    the usual NLL minimisation (see
+    :func:`~gauss_flows.fit_gaussianization_flow`).
 
     Args:
         x: Training data of shape ``(n, d)``.
@@ -136,16 +139,19 @@ def fit_rbig(
             ``random_state + block_idx * 1000 + dim_idx``. Defaults to 0.
 
     Returns:
-        A :class:`flowjax.distributions.Transformed` distribution over
-        ``R^d`` whose bijection Gaussianises ``x``.
+        A flowjax ``Transformed`` distribution over ℝ^d whose bijection
+        Gaussianises ``x``, with ``log_prob`` and ``sample``.
+
+    Raises:
+        ValueError: If ``x`` is not 2-D.
 
     Example:
         >>> import jax.random as jr
         >>> from gauss_flows import fit_rbig
         >>> x = jr.normal(jr.key(0), (500, 2))
         >>> flow = fit_rbig(x, n_layers=4, n_components=4)
-        >>> float(flow.log_prob(x).mean())  # doctest: +SKIP
-        -2.8...
+        >>> flow.sample(jr.key(1), (8,)).shape
+        (8, 2)
     """
     x_np = np.asarray(x, dtype=np.float32)
     if x_np.ndim != 2:
@@ -347,18 +353,20 @@ def fit_rbig_coupling(
     log_scale_bound: float = 5.0,
     random_state: int = 0,
 ) -> Transformed:
-    """Warm-start an RBIG-style coupling flow.
+    """Warm-start an RBIG-style coupling flow in closed form.
 
     Each block is ``[FixedRotation (PCA), MixtureGaussianCDFCoupling]``.
-    The coupling's conditioner is initialised with a zero kernel and a
-    bias set from per-b-dim GMM fits (via :func:`_init_coupling_from_fits`),
-    so the layer starts as a constant-in-``x_a`` mixture-CDF transform on
-    the ``x_b`` half — numerically equivalent to a diagonal marginal fit
-    on the ``x_b`` dims. Gradient training can then break the constancy
-    and let the conditioner modulate on ``x_a``.
+    The coupling's conditioner is initialised in closed form — no gradient
+    training — with a zero kernel and a bias set from per-b-dim sklearn
+    ``GaussianMixture`` fits (via :func:`_init_coupling_from_fits`), so
+    the layer starts as a constant-in-``x_a`` mixture-CDF transform on the
+    ``x_b`` half — numerically equivalent to a diagonal marginal fit on
+    the ``x_b`` dims. Gradient training (see
+    :func:`~gauss_flows.fit_gaussianization_flow`) can then break the
+    constancy and let the conditioner modulate on ``x_a``.
 
     Args:
-        x: Training data of shape ``(n, d)``.
+        x: Training data of shape ``(n, d)`` with even ``d ≥ 2``.
         key: JAX random key for the conditioner MLPs' hidden-layer init.
         n_layers: Number of ``(rotation, coupling)`` blocks. Defaults to 6.
         n_components: Mixture components per transformed dim. Defaults to 8.
@@ -369,7 +377,19 @@ def fit_rbig_coupling(
         random_state: Base seed for per-dim GMM EM fits. Defaults to 0.
 
     Returns:
-        A :class:`flowjax.distributions.Transformed` distribution.
+        A flowjax ``Transformed`` distribution with ``log_prob`` and ``sample``.
+
+    Raises:
+        ValueError: If ``x`` is not 2-D, or ``d`` is less than 2 or odd
+            (the half-swap coupling pair requires an even number of dims).
+
+    Example:
+        >>> import jax.random as jr
+        >>> from gauss_flows import fit_rbig_coupling
+        >>> x = jr.normal(jr.key(0), (500, 2))
+        >>> flow = fit_rbig_coupling(x, jr.key(1), n_layers=2, n_components=4)
+        >>> flow.sample(jr.key(2), (8,)).shape
+        (8, 2)
     """
     import jax.random as jr
 

--- a/src/gauss_flows/_src/nn/diffeq_nets.py
+++ b/src/gauss_flows/_src/nn/diffeq_nets.py
@@ -195,6 +195,16 @@ class DiffeqConcat(eqx.Module):
         - Input ``condition``: ``(1 + control_dim,)`` or ``None`` when
           ``control_dim == 0``
         - Output: ``(dim,)``
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import DiffeqConcat, pack_time_control
+        >>> net = DiffeqConcat(jr.key(0), in_dim=3, control_dim=2, hidden=(16, 16))
+        >>> x = jnp.ones((3,))
+        >>> cond = pack_time_control(0.5, jnp.array([1.0, -1.0]))
+        >>> net(0.25, x, cond).shape
+        (3,)
     """
 
     in_dim: int = eqx.field(static=True)

--- a/src/gauss_flows/_src/transforms/_sphere_utils.py
+++ b/src/gauss_flows/_src/transforms/_sphere_utils.py
@@ -17,10 +17,18 @@ def _safe_normalize(x: Array) -> Array:
 
 
 def tangent_basis(x: Array) -> Array:
-    """Return an orthonormal basis of the tangent space ``T_x S^d``.
+    """Return an orthonormal basis of the tangent space ``Tₓ Sᵈ``.
 
     Uses a Householder reflection that maps ``x`` to ``±e₁`` and then takes
     columns ``2..d+1`` of that orthogonal matrix.
+
+    Args:
+        x: A point in ``ℝ^{d+1}`` (normalised internally to the sphere),
+            shape ``(d+1,)``.
+
+    Returns:
+        Tangent basis ``E`` of shape ``(d+1, d)`` with ``Eᵀ E = I`` and
+        ``xᵀ E = 0``.
 
     Shape:
         Input: ``(d+1,)``.
@@ -52,8 +60,17 @@ def expmap_sphere(
 ) -> Array:
     """Map a tangent vector at ``x`` to the sphere via the exponential map.
 
-    ``expmap(x, v) = x cos(||v||) + v sin(||v||) / ||v||`` with the
-    ``sin(r) / r`` factor evaluated via ``sinc`` for stability at ``r → 0``.
+    ``expmap(x, v) = x·cos(‖v‖) + v·sin(‖v‖) / ‖v‖`` with the ``sin(r) / r``
+    factor evaluated via ``sinc`` for stability at ``r → 0``. The component
+    of ``v`` along ``x`` is removed first, so ``v`` need not be exactly
+    tangent.
+
+    Args:
+        x: Base point in ``ℝ^{d+1}`` (normalised internally), shape ``(d+1,)``.
+        v: Tangent vector at ``x``, shape ``(d+1,)``.
+
+    Returns:
+        The point ``expmap(x, v)`` on the sphere, shape ``(d+1,)``.
 
     Shape:
         ``x`` and ``v`` are single events of shape ``(d+1,)``.
@@ -82,15 +99,24 @@ def logmap_sphere(
 ) -> Array:
     """Return the tangent vector at ``x`` whose exp-map reaches ``y``.
 
-    The log map is not uniquely defined when ``y`` is antipodal to ``x``; this
+    Inverse of :func:`expmap_sphere`: ``expmap(x, logmap(x, y)) ≈ y``. The
+    log map is not uniquely defined when ``y`` is antipodal to ``x``; this
     implementation returns ``π · e`` for a deterministic tangent direction
     ``e`` obtained from :func:`tangent_basis`, which at least satisfies
-    ``||logmap|| == π`` (the geodesic distance to the antipode) and is
+    ``‖logmap‖ == π`` (the geodesic distance to the antipode) and is
     continuous under perturbations of ``x``.
+
+    Args:
+        x: Base point on the sphere in ``ℝ^{d+1}`` (normalised internally),
+            shape ``(d+1,)``.
+        y: Target point on the sphere, shape ``(d+1,)``.
+
+    Returns:
+        The tangent vector in ``Tₓ Sᵈ`` reaching ``y``, shape ``(d+1,)``.
 
     Shape:
         ``x`` and ``y`` are single points on the sphere with shape ``(d+1,)``.
-        Returns a tangent vector in ``T_x S^d`` with shape ``(d+1,)``.
+        Returns a tangent vector in ``Tₓ Sᵈ`` with shape ``(d+1,)``.
 
     Example:
         >>> import jax.numpy as jnp

--- a/src/gauss_flows/_src/transforms/bijections/classic/planar.py
+++ b/src/gauss_flows/_src/transforms/bijections/classic/planar.py
@@ -15,21 +15,40 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 
 
 class PlanarFlow(AbstractBijection):
-    """Planar flow bijection (Rezende & Mohamed 2015).
+    """Planar normalizing-flow bijection (Rezende & Mohamed 2015).
 
-    Applies ``y = x + u_hat * tanh(w . x + b)`` where ``u_hat`` is the
-    projection of ``u`` that guarantees ``w . u_hat >= -1`` (the
-    invertibility condition from the original paper).
+    Applies the rank-1 perturbation ``y = x + û · tanh(w · x + b)``, where ``û``
+    is the reparameterisation of the raw vector ``u`` that guarantees
+    ``w · û ≥ −1`` — the invertibility condition from the original paper. The
+    log-abs-det collapses to ``log|1 + (û · w)·(1 − tanh²(w·x + b))|``.
+
+    The forward map has no closed-form inverse, so this layer is generative-only:
+    use it in the sampling / variational-inference direction via
+    :meth:`flowjax.distributions.Transformed.sample_and_log_prob`.
 
     Args:
-        key: JAX random key.
-        shape: Shape of the input ``(n_dims,)``.
+        key: PRNG key used to initialise ``u`` and ``w``.
+        shape: Event shape ``(n_dims,)``. Must be 1-D.
         scale_init: Std of the Gaussian used to initialise ``u`` and ``w``.
+            Defaults to ``0.01``.
 
-    Note:
-        No algebraic inverse; ``inverse_and_log_det`` raises
-        :class:`NotImplementedError`. Use only in the generative
-        (sample / VI) direction.
+    Raises:
+        ValueError: If ``shape`` is not 1-D.
+        NotImplementedError: From ``inverse_and_log_det`` — there is no
+            algebraic inverse.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   not implemented (raises)
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import PlanarFlow
+        >>> flow = PlanarFlow(jr.key(0), shape=(3,))
+        >>> y, log_det = flow.transform_and_log_det(jnp.ones((3,)))
+        >>> y.shape, log_det.shape
+        ((3,), ())
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/classic/sylvester.py
+++ b/src/gauss_flows/_src/transforms/bijections/classic/sylvester.py
@@ -17,33 +17,48 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 class SylvesterFlow(AbstractBijection):
     """Sylvester normalizing flow (van den Berg et al. 2018).
 
-    Generalises :class:`PlanarFlow` to rank ``M <= D``:
+    Generalises :class:`PlanarFlow` from a rank-1 to a rank-``M`` (``M ≤ D``)
+    perturbation:
 
-    .. code-block::
+        ``y = x + Q · R̃ · tanh(R · Qᵀ · x + b)``
 
-        y = x + Q @ R_tilde @ tanh(R @ Q^T @ x + b)
+    where ``Q ∈ ℝ^{D×M}`` has orthonormal columns (parameterised via ``M``
+    Householder reflections applied to ``I_D``), and ``R``, ``R̃`` are ``M×M``
+    upper-triangular matrices whose diagonals are constrained with ``tanh`` to
+    keep ``|diag(R) · diag(R̃)| < 1`` — sufficient for invertibility. Via
+    Sylvester's determinant identity the log-abs-det reduces to a sum over the
+    ``M`` diagonal entries, costing ``O(M)`` rather than ``O(D)``.
 
-    where ``Q in R^{D x M}`` has orthonormal columns (parameterised via
-    ``M`` Householder reflections on ``I_D``), and ``R``, ``R_tilde`` are
-    ``M x M`` upper-triangular matrices with diagonal entries constrained
-    via ``tanh`` (to keep ``|diag(R) * diag(R_tilde)| < 1``, which is
-    sufficient for invertibility).
-
-    Via Sylvester's determinant identity the log-abs-det reduces to a
-    sum over the ``M`` diagonal entries.
+    The forward map has no closed-form inverse, so this layer is generative-only:
+    use it in the sampling / variational-inference direction via
+    :meth:`flowjax.distributions.Transformed.sample_and_log_prob`.
 
     Args:
-        key: JAX random key.
-        shape: Shape of the input ``(n_dims,)``.
-        rank: Rank ``M`` of the flow. Defaults to the full input dim.
+        key: PRNG key used to initialise all parameters.
+        shape: Event shape ``(n_dims,)``. Must be 1-D.
+        rank: Rank ``M`` of the flow. Defaults to the full input dim ``D``.
         scale_init: Std of the Gaussian used to initialise the Householder
             vectors (offset from the identity), the strict upper-triangular
-            entries of ``R`` and ``R_tilde``, and their raw diagonal
-            parameter vectors.
+            entries of ``R`` and ``R̃``, and their raw diagonal parameter
+            vectors. Defaults to ``0.01``.
 
-    Note:
-        No algebraic inverse; ``inverse_and_log_det`` raises
-        :class:`NotImplementedError`. Use only in the generative direction.
+    Raises:
+        ValueError: If ``shape`` is not 1-D or ``rank`` is outside ``[1, D]``.
+        NotImplementedError: From ``inverse_and_log_det`` — there is no
+            algebraic inverse.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   not implemented (raises)
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import SylvesterFlow
+        >>> flow = SylvesterFlow(jr.key(0), shape=(4,), rank=2)
+        >>> y, log_det = flow.transform_and_log_det(jnp.ones((4,)))
+        >>> y.shape, log_det.shape
+        ((4,), ())
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/coupling/affine.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/affine.py
@@ -5,26 +5,55 @@ from __future__ import annotations
 import jax.numpy as jnp
 from flowjax.bijections import AbstractBijection, Coupling
 from flowjax.bijections.affine import Affine
+from jax import Array
 from jaxtyping import ArrayLike, PRNGKeyArray
 
 
 class AffineCoupling(AbstractBijection):
     """Affine coupling layer.
 
-    Splits input into two halves: the first half is unchanged (the
-    *data-dependent* conditioning input), and the second half is
-    transformed by an affine function whose parameters are produced by an
-    inner MLP. With ``cond_dim > 0`` the same MLP additionally consumes an
-    external context vector, concatenated to the first-half input.
+    Splits the input into two halves along its single (1D) axis. The first
+    ``n_dims // 2`` dims pass through unchanged and feed an inner conditioner
+    MLP that emits per-dim affine parameters ``(shift, log_scale)`` for the
+    remaining dims, which are transformed as ``y = x · exp(log_scale) + shift``.
+    With ``cond_dim`` set, the same MLP additionally consumes an external
+    context vector concatenated onto the first-half input.
+
+    Wraps :class:`flowjax.bijections.Coupling` with an
+    :class:`flowjax.bijections.affine.Affine` transformer; this class adds the
+    convention that an unconditional layer (``cond_dim=None``) drops any
+    incoming ``condition`` so a base-only condition cannot leak into the inner
+    MLP.
 
     Args:
-        key: JAX random key.
-        shape: Shape of the input ``(n_dims,)``.
+        key: JAX random key for conditioner MLP initialisation.
+        shape: Event shape ``(n_dims,)``. Only 1D inputs are supported.
         cond_dim: If not ``None``, the layer expects a 1-D ``condition`` of
             shape ``(cond_dim,)`` at call time and concatenates it onto the
             inner MLP's input. Defaults to ``None`` (unconditional).
         nn_width: Hidden layer width of the conditioner MLP. Defaults to 64.
         nn_depth: Depth of the conditioner MLP. Defaults to 2.
+
+    Raises:
+        ValueError: If ``shape`` is not 1D, or ``cond_dim`` is a non-positive int.
+
+    Shape:
+        - transform_and_log_det: (n_dims,) → (n_dims,), scalar log_det
+        - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
+        (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``)
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import AffineCoupling
+        >>> t = AffineCoupling(jr.key(0), shape=(4,))
+        >>> x = jr.normal(jr.key(1), (4,))
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        (4,)
+        >>> x_rec, log_det_inv = t.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-5))
+        True
     """
 
     shape: tuple[int, ...]
@@ -61,7 +90,20 @@ class AffineCoupling(AbstractBijection):
             nn_depth=nn_depth,
         )
 
-    def transform_and_log_det(self, x: ArrayLike, condition=None):
+    def transform_and_log_det(
+        self, x: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array]:
+        """Forward map ``x → y`` and its scalar log-determinant.
+
+        Args:
+            x: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when the layer is
+                conditional; ignored (dropped) when ``cond_dim=None``.
+
+        Returns:
+            Tuple ``(y, log_det)`` with ``y`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         # Drop the condition when the layer is unconditional. flowjax's inner
         # Coupling unconditionally concatenates any non-None condition with
         # the untransformed half, which would crash the inner MLP if we let
@@ -70,7 +112,20 @@ class AffineCoupling(AbstractBijection):
             condition = None
         return self._coupling.transform_and_log_det(jnp.asarray(x), condition)
 
-    def inverse_and_log_det(self, y: ArrayLike, condition=None):
+    def inverse_and_log_det(
+        self, y: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array]:
+        """Inverse map ``y → x`` and its scalar log-determinant.
+
+        Args:
+            y: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when the layer is
+                conditional; ignored (dropped) when ``cond_dim=None``.
+
+        Returns:
+            Tuple ``(x, log_det)`` with ``x`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         if self.cond_shape is None:
             condition = None
         return self._coupling.inverse_and_log_det(jnp.asarray(y), condition)

--- a/src/gauss_flows/_src/transforms/bijections/coupling/circular_spline.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/circular_spline.py
@@ -37,27 +37,44 @@ class CircularRQSplineCoupling(AbstractBijection):
     2. The conditioner sees ``[sin(x_cond), cos(x_cond)]`` features rather than
        raw angles, so it cannot distinguish ``-π+ε`` from ``+π-ε``.
 
-    Shape:
-        Input/output: ``(n_dims,)`` (single event). ``log_det`` is a scalar
-        ``Array``. The transformed slice is ``input[untransformed_dim:]``.
+    The transformed slice is ``input[untransformed_dim:]``; the leading
+    ``untransformed_dim`` dims pass through unchanged and supply the
+    Fourier-feature conditioning. This is unconditional — there is no external
+    ``condition`` argument (``cond_shape`` is ``None``).
 
     Args:
         key: JAX random key for the conditioner MLP.
         shape: Input shape ``(n_dims,)``. Every dim is treated as periodic.
+            Requires ``n_dims >= 2``.
         n_bins: Number of spline bins. Defaults to 8.
-        bound: Half-width of the circular interval. Defaults to ``π``.
+        bound: Half-width of the circular interval; period is ``2·bound``.
+            Defaults to ``π``.
         untransformed_dim: Number of leading dims left unchanged (used as
-            conditioner inputs). Defaults to ``n_dims // 2``.
+            conditioner inputs). Must lie in ``(0, n_dims)``. Defaults to
+            ``n_dims // 2``.
         nn_width: Hidden layer width for the conditioner MLP. Defaults to 64.
         nn_depth: Depth of the conditioner MLP. Defaults to 2.
+
+    Raises:
+        ValueError: If ``shape`` is not 1D, ``n_dims < 2``, or
+            ``untransformed_dim`` is not in ``(0, n_dims)``.
+
+    Shape:
+        - transform_and_log_det: (n_dims,) → (n_dims,), scalar log_det
+        - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
 
     Example:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import CircularRQSplineCoupling
-        >>> key = jr.key(0)
-        >>> coupling = CircularRQSplineCoupling(key, shape=(4,), n_bins=8)
-        >>> y, log_det = coupling.transform_and_log_det(jr.uniform(key, (4,)))
+        >>> coupling = CircularRQSplineCoupling(jr.key(0), shape=(4,), n_bins=8)
+        >>> x = jr.uniform(jr.key(1), (4,), minval=-jnp.pi, maxval=jnp.pi)
+        >>> y, log_det = coupling.transform_and_log_det(x)
+        >>> y.shape
+        (4,)
+        >>> x_rec, log_det_inv = coupling.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-4))
+        True
 
     Reference:
         Rezende et al. 2020, *Normalizing Flows on Tori and Spheres*.
@@ -117,7 +134,20 @@ class CircularRQSplineCoupling(AbstractBijection):
         # x_cond: (untransformed_dim,) -> features: (2 * untransformed_dim,)
         return jnp.concatenate([jnp.sin(x_cond), jnp.cos(x_cond)])
 
-    def transform_and_log_det(self, x: Array, condition=None) -> tuple[Array, Array]:
+    def transform_and_log_det(
+        self, x: Array, condition: Array | None = None
+    ) -> tuple[Array, Array]:
+        """Forward map ``x → y`` on the torus and its scalar log-determinant.
+
+        Args:
+            x: Single event of shape ``(n_dims,)``; wrapped into
+                ``[−bound, bound]`` before transforming.
+            condition: Unused (this layer is unconditional).
+
+        Returns:
+            Tuple ``(y, log_det)`` with ``y`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         x_arr = jnp.asarray(x)
         x_wrapped = _wrap_all(x_arr, self.bound)
         x_cond = x_wrapped[: self.untransformed_dim]
@@ -128,7 +158,20 @@ class CircularRQSplineCoupling(AbstractBijection):
         y = jnp.concatenate([x_cond, y_trans])
         return y, log_det
 
-    def inverse_and_log_det(self, y: Array, condition=None) -> tuple[Array, Array]:
+    def inverse_and_log_det(
+        self, y: Array, condition: Array | None = None
+    ) -> tuple[Array, Array]:
+        """Inverse map ``y → x`` on the torus and its scalar log-determinant.
+
+        Args:
+            y: Single event of shape ``(n_dims,)``; wrapped into
+                ``[−bound, bound]`` before transforming.
+            condition: Unused (this layer is unconditional).
+
+        Returns:
+            Tuple ``(x, log_det)`` with ``x`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         y_arr = jnp.asarray(y)
         y_wrapped = _wrap_all(y_arr, self.bound)
         y_cond = y_wrapped[: self.untransformed_dim]

--- a/src/gauss_flows/_src/transforms/bijections/coupling/continuous_affine_coupling.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/continuous_affine_coupling.py
@@ -50,11 +50,15 @@ class ContinuousAffineCoupling(AbstractBijection):
             :class:`gauss_flows.TimeFourier` gate. Ignored when ``time_net`` is
             provided.
 
+    Raises:
+        ValueError: If ``shape`` is not 1D, ``dim < 2``, or ``control_dim`` is
+            negative.
+
     Shape:
-        - Input ``x``: ``(dim,)``
-        - Condition: ``(1 + control_dim,)`` packed as ``[t, c]``
-        - Output ``y``: ``(dim,)``
-        - ``log_det``: scalar ``()``
+        - transform_and_log_det: (dim,) → (dim,), scalar log_det
+        - inverse_and_log_det:   (dim,) → (dim,), scalar log_det
+        (always takes a ``condition`` of shape ``(1 + control_dim,)`` packed as
+        ``[t, c]`` via :func:`gauss_flows.pack_time_control`)
 
     Example:
         >>> import jax.numpy as jnp
@@ -149,6 +153,20 @@ class ContinuousAffineCoupling(AbstractBijection):
         x: ArrayLike,
         condition: ArrayLike | None = None,
     ) -> tuple[Array, Array]:
+        """Forward map ``x → y`` and its scalar log-determinant.
+
+        Args:
+            x: Single event of shape ``(dim,)``.
+            condition: Packed ``[t, c]`` of shape ``(1 + control_dim,)`` (build
+                it with :func:`gauss_flows.pack_time_control`). Required.
+
+        Returns:
+            Tuple ``(y, log_det)`` with ``y`` of shape ``(dim,)`` and a scalar
+            ``log_det``.
+
+        Raises:
+            ValueError: If ``condition`` is ``None``.
+        """
         x = jnp.asarray(x)
         passive = x[: self.untransformed_dim]
         active = x[self.untransformed_dim :]
@@ -163,6 +181,20 @@ class ContinuousAffineCoupling(AbstractBijection):
         y: ArrayLike,
         condition: ArrayLike | None = None,
     ) -> tuple[Array, Array]:
+        """Inverse map ``y → x`` and its scalar log-determinant.
+
+        Args:
+            y: Single event of shape ``(dim,)``.
+            condition: Packed ``[t, c]`` of shape ``(1 + control_dim,)`` (build
+                it with :func:`gauss_flows.pack_time_control`). Required.
+
+        Returns:
+            Tuple ``(x, log_det)`` with ``x`` of shape ``(dim,)`` and a scalar
+            ``log_det``.
+
+        Raises:
+            ValueError: If ``condition`` is ``None``.
+        """
         y = jnp.asarray(y)
         passive = y[: self.untransformed_dim]
         active_y = y[self.untransformed_dim :]

--- a/src/gauss_flows/_src/transforms/bijections/coupling/deepsigmoid.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/deepsigmoid.py
@@ -155,21 +155,30 @@ class DeepSigmoidCoupling(AbstractBijection):
         nn_width: Hidden layer width of the conditioner MLP. Defaults to 64.
         nn_depth: Depth of the conditioner MLP. Defaults to 2.
 
+    Raises:
+        ValueError: If ``shape`` is not 1D, or ``cond_dim`` is a non-positive int.
+
     Shape:
-        - Input  ``x``:  ``(n_dims,)`` (with ``n_dims`` even-friendly; the
-          coupling splits into ``n_dims // 2`` kept + transformed halves).
-        - Output ``y``:  ``(n_dims,)``
-        - ``log_det``:   scalar (sum over transformed dims of ``log(dy/dx)``)
+        - transform_and_log_det: (n_dims,) → (n_dims,), scalar log_det
+        - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
+        (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``;
+        the coupling splits into ``n_dims // 2`` kept + transformed halves, and
+        ``log_det`` sums ``log(dy/dx)`` over the transformed dims)
 
     Example:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import DeepSigmoidCoupling
-        >>>
         >>> coupling = DeepSigmoidCoupling(
         ...     key=jr.key(0), shape=(4,), n_components=8, nn_width=32, nn_depth=2,
         ... )
-        >>> y, log_det = coupling.transform_and_log_det(jr.normal(jr.key(1), (4,)))
+        >>> x = jr.normal(jr.key(1), (4,))
+        >>> y, log_det = coupling.transform_and_log_det(x)
+        >>> y.shape
+        (4,)
+        >>> x_rec, log_det_inv = coupling.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-4))
+        True
     """
 
     shape: tuple[int, ...]
@@ -207,12 +216,38 @@ class DeepSigmoidCoupling(AbstractBijection):
             nn_depth=nn_depth,
         )
 
-    def transform_and_log_det(self, x: ArrayLike, condition=None):
+    def transform_and_log_det(
+        self, x: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array]:
+        """Forward map ``x → y`` and its scalar log-determinant.
+
+        Args:
+            x: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when the layer is
+                conditional; ignored (dropped) when ``cond_dim=None``.
+
+        Returns:
+            Tuple ``(y, log_det)`` with ``y`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         if self.cond_shape is None:
             condition = None
         return self._coupling.transform_and_log_det(jnp.asarray(x), condition)
 
-    def inverse_and_log_det(self, y: ArrayLike, condition=None):
+    def inverse_and_log_det(
+        self, y: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array]:
+        """Inverse map ``y → x`` and its scalar log-determinant.
+
+        Args:
+            y: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when the layer is
+                conditional; ignored (dropped) when ``cond_dim=None``.
+
+        Returns:
+            Tuple ``(x, log_det)`` with ``x`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         if self.cond_shape is None:
             condition = None
         return self._coupling.inverse_and_log_det(jnp.asarray(y), condition)

--- a/src/gauss_flows/_src/transforms/bijections/coupling/gin_coupling.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/gin_coupling.py
@@ -55,9 +55,9 @@ class GINCoupling(AbstractBijection):
         nn_depth: Depth of the conditioner MLP. Defaults to 2.
 
     Shape:
-        - Input ``x``: ``(n_dims,)``
-        - Output ``y``: ``(n_dims,)``
-        - ``log_det``: scalar ``()``, always exactly zero
+        - transform_and_log_det: (n_dims,) → (n_dims,), scalar log_det (≡ 0)
+        - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det (≡ 0)
+        (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``)
 
     Example:
         >>> import jax.numpy as jnp
@@ -135,6 +135,17 @@ class GINCoupling(AbstractBijection):
         x: ArrayLike,
         condition: ArrayLike | None = None,
     ) -> tuple[Array, Array]:
+        """Forward map ``x → y`` with volume-preserving ``log_det ≡ 0``.
+
+        Args:
+            x: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when conditional;
+                ``None`` otherwise.
+
+        Returns:
+            Tuple ``(y, log_det)`` with ``y`` of shape ``(n_dims,)`` and a
+            scalar ``log_det`` that is exactly zero.
+        """
         x = jnp.asarray(x)
         passive = x[: self.untransformed_dim]
         active = x[self.untransformed_dim :]
@@ -151,6 +162,17 @@ class GINCoupling(AbstractBijection):
         y: ArrayLike,
         condition: ArrayLike | None = None,
     ) -> tuple[Array, Array]:
+        """Inverse map ``y → x`` with volume-preserving ``log_det ≡ 0``.
+
+        Args:
+            y: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when conditional;
+                ``None`` otherwise.
+
+        Returns:
+            Tuple ``(x, log_det)`` with ``x`` of shape ``(n_dims,)`` and a
+            scalar ``log_det`` that is exactly zero.
+        """
         y = jnp.asarray(y)
         passive = y[: self.untransformed_dim]
         active_y = y[self.untransformed_dim :]

--- a/src/gauss_flows/_src/transforms/bijections/coupling/mixture_cdf.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/mixture_cdf.py
@@ -145,10 +145,27 @@ class MixtureGaussianCDFCoupling(AbstractBijection):
         log_scale_bound: Tanh bound applied to per-dim log-scales. Defaults
             to 5.0 (σ ∈ [exp(-5), exp(5)] ≈ [6.7e-3, 148]).
 
+    Raises:
+        ValueError: If ``shape`` is not 1D, ``cond_dim`` is a non-positive int,
+            or ``n_dims < 2`` (no non-trivial split).
+
     Shape:
-        - Input ``x``: ``(n_dims,)``
-        - Output ``y``: ``(n_dims,)``
-        - ``log_det``: scalar ``()``
+        - transform_and_log_det: (n_dims,) → (n_dims,), scalar log_det
+        - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
+        (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``)
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import MixtureGaussianCDFCoupling
+        >>> coupling = MixtureGaussianCDFCoupling(jr.key(0), shape=(4,), n_components=4)
+        >>> x = jr.normal(jr.key(1), (4,))
+        >>> y, log_det = coupling.transform_and_log_det(x)
+        >>> y.shape
+        (4,)
+        >>> x_rec, log_det_inv = coupling.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-4))
+        True
     """
 
     shape: tuple[int, ...]
@@ -197,12 +214,38 @@ class MixtureGaussianCDFCoupling(AbstractBijection):
             nn_depth=nn_depth,
         )
 
-    def transform_and_log_det(self, x: ArrayLike, condition=None):
+    def transform_and_log_det(
+        self, x: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array]:
+        """Forward map ``x → z`` and its scalar log-determinant.
+
+        Args:
+            x: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when the layer is
+                conditional; ignored (dropped) when ``cond_dim=None``.
+
+        Returns:
+            Tuple ``(z, log_det)`` with ``z`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         if self.cond_shape is None:
             condition = None
         return self._coupling.transform_and_log_det(jnp.asarray(x), condition)
 
-    def inverse_and_log_det(self, y: ArrayLike, condition=None):
+    def inverse_and_log_det(
+        self, y: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array]:
+        """Inverse map ``z → x`` and its scalar log-determinant.
+
+        Args:
+            y: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when the layer is
+                conditional; ignored (dropped) when ``cond_dim=None``.
+
+        Returns:
+            Tuple ``(x, log_det)`` with ``x`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         if self.cond_shape is None:
             condition = None
         return self._coupling.inverse_and_log_det(jnp.asarray(y), condition)

--- a/src/gauss_flows/_src/transforms/bijections/coupling/spline.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/spline.py
@@ -4,26 +4,57 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 from flowjax.bijections import AbstractBijection, Coupling, RationalQuadraticSpline
+from jax import Array
 from jaxtyping import ArrayLike, PRNGKeyArray
 
 
 class RQSplineCoupling(AbstractBijection):
     """Rational quadratic spline coupling layer.
 
-    Like :class:`AffineCoupling`, but uses a rational quadratic spline as
-    the per-dim transformer. With ``cond_dim > 0`` the inner MLP additionally
-    consumes an external context vector, concatenated to the first-half
-    input.
+    Splits the input into two halves along its single (1D) axis. The first
+    ``n_dims // 2`` dims pass through unchanged and feed an inner conditioner
+    MLP that emits the knot/derivative parameters of a monotone rational
+    quadratic spline applied per-dim to the remaining half. Like
+    :class:`AffineCoupling` but with a far more expressive per-dim
+    transformer; with ``cond_dim`` set, the inner MLP additionally consumes
+    an external context vector concatenated onto the first-half input.
+
+    Wraps :class:`flowjax.bijections.Coupling` with a
+    :class:`flowjax.bijections.RationalQuadraticSpline` transformer; this
+    class adds the convention that an unconditional layer drops any incoming
+    ``condition`` so a base-only condition cannot leak into the inner MLP.
 
     Args:
-        key: JAX random key.
-        shape: Shape of the input ``(n_dims,)``.
-        n_bins: Number of spline bins. Defaults to 8.
-        interval: Spline interval. Defaults to 5.0.
+        key: JAX random key for conditioner MLP initialisation.
+        shape: Event shape ``(n_dims,)``. Only 1D inputs are supported.
+        n_bins: Number of spline bins (knots). Defaults to 8.
+        interval: Half-width of the spline interval ``[−interval, interval]``;
+            the transformer is affine (identity-tail) outside it. Defaults to 5.0.
         cond_dim: If not ``None``, the layer expects a 1-D ``condition`` of
             shape ``(cond_dim,)`` at call time. Defaults to ``None``.
         nn_width: Hidden layer width of the conditioner MLP. Defaults to 64.
         nn_depth: Depth of the conditioner MLP. Defaults to 2.
+
+    Raises:
+        ValueError: If ``shape`` is not 1D, or ``cond_dim`` is a non-positive int.
+
+    Shape:
+        - transform_and_log_det: (n_dims,) → (n_dims,), scalar log_det
+        - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
+        (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``)
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import RQSplineCoupling
+        >>> t = RQSplineCoupling(jr.key(0), shape=(4,))
+        >>> x = jr.normal(jr.key(1), (4,))
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        (4,)
+        >>> x_rec, log_det_inv = t.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-5))
+        True
     """
 
     shape: tuple[int, ...]
@@ -62,12 +93,38 @@ class RQSplineCoupling(AbstractBijection):
             nn_depth=nn_depth,
         )
 
-    def transform_and_log_det(self, x: ArrayLike, condition=None):
+    def transform_and_log_det(
+        self, x: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array]:
+        """Forward map ``x → y`` and its scalar log-determinant.
+
+        Args:
+            x: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when the layer is
+                conditional; ignored (dropped) when ``cond_dim=None``.
+
+        Returns:
+            Tuple ``(y, log_det)`` with ``y`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         if self.cond_shape is None:
             condition = None
         return self._coupling.transform_and_log_det(jnp.asarray(x), condition)
 
-    def inverse_and_log_det(self, y: ArrayLike, condition=None):
+    def inverse_and_log_det(
+        self, y: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array]:
+        """Inverse map ``y → x`` and its scalar log-determinant.
+
+        Args:
+            y: Single event of shape ``(n_dims,)``.
+            condition: Context of shape ``(cond_dim,)`` when the layer is
+                conditional; ignored (dropped) when ``cond_dim=None``.
+
+        Returns:
+            Tuple ``(x, log_det)`` with ``x`` of shape ``(n_dims,)`` and a
+            scalar ``log_det``.
+        """
         if self.cond_shape is None:
             condition = None
         return self._coupling.inverse_and_log_det(jnp.asarray(y), condition)

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/circular_spline.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/circular_spline.py
@@ -32,15 +32,27 @@ class CircularRationalQuadraticSpline(AbstractBijection):
     replaces the ``derivatives`` Parameterize with a tied variant — one fewer
     free parameter than the unconstrained spline.
 
-    Shape:
-        Scalar bijection: ``shape == ()``. Use inside a ``Coupling`` or ``Vmap``
-        to apply it to a vector of periodic coordinates.
-
     Args:
         knots: Number of bins.
         bound: Half-width of the periodic interval. Defaults to ``π``.
         min_derivative: Minimum derivative at any knot. Defaults to ``1e-3``.
         min_width: Minimum bin width. Defaults to ``1e-3``.
+
+    Shape:
+        Scalar bijection: ``shape == ()``. Use inside a ``Coupling`` or ``Vmap``
+        to apply it to a vector of periodic coordinates.
+
+        - transform_and_log_det: ``()`` → ``()``, scalar log_det
+        - inverse_and_log_det:   ``()`` → ``()``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import CircularRationalQuadraticSpline
+        >>> t = CircularRationalQuadraticSpline(knots=8)  # bound = π
+        >>> x = jnp.array(0.3)  # scalar angle inside [−π, π]
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        ()
     """
 
     shape: ClassVar[tuple[int, ...]] = ()

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
@@ -59,9 +59,10 @@ class HistogramCDF(AbstractBijection):
         inv_interp: Optional pre-built inverse-CDF interpolator.
 
     Shape:
-        - Input  ``x``:  ``(n_dims,)``
-        - Output ``y``:  ``(n_dims,)`` in ``[0, 1]``
-        - ``log_det``:   scalar (sum of per-dim ``log(density)``)
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)`` in ``[0, 1]``,
+          scalar log_det (sum of per-dim ``log(density)``)
+        - inverse_and_log_det:   ``(n_dims,)`` in ``[0, 1]`` → ``(n_dims,)``,
+          scalar log_det
 
     Example:
         Fit and transform on Gaussian data:
@@ -69,10 +70,11 @@ class HistogramCDF(AbstractBijection):
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import HistogramCDF
-        >>>
         >>> data = jr.normal(jr.key(0), (5000, 3))
         >>> hist = HistogramCDF(n_bins=64, shape=(3,)).fit(data)
         >>> y, log_det = hist.transform_and_log_det(jnp.zeros(3))
+        >>> y.shape
+        (3,)
         >>> # y is roughly [0.5, 0.5, 0.5] (CDF at 0 of N(0,1) ≈ 0.5).
     """
 

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/inverse_gauss.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/inverse_gauss.py
@@ -12,13 +12,33 @@ from jaxtyping import ArrayLike
 
 
 class InverseGaussCDF(AbstractBijection):
-    """Apply the inverse Gaussian CDF (probit function) element-wise.
+    """Apply the inverse Gaussian CDF (probit) element-wise.
 
-    This maps uniform marginals to Gaussian marginals using the probit function.
-    It is typically used after a CDF transform.
+    Maps uniform marginals on ``[0, 1]`` to standard-Gaussian marginals via the
+    probit function ``Φ⁻¹``. This is the standard final step of a marginal
+    Gaussianization layer: a CDF transform (histogram, mixture, …) sends data to
+    uniform, then this layer sends uniform to ``N(0, 1)``. The forward map is
+    ``y = Φ⁻¹(x)``; inputs are clipped to ``[1e−6, 1 − 1e−6]`` to keep the probit
+    finite at the boundaries. The inverse is the Gaussian CDF ``x = Φ(y)``.
 
     Args:
-        shape: Shape of the input.
+        shape: Event shape ``(n_dims,)``. The transform is applied
+            independently to each entry.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import InverseGaussCDF
+        >>> t = InverseGaussCDF(shape=(3,))
+        >>> x = jnp.array([0.2, 0.5, 0.8])
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        (3,)
+        >>> bool(jnp.allclose(y[1], 0.0))  # Φ⁻¹(0.5) == 0
+        True
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/mixture_cdf.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/mixture_cdf.py
@@ -20,14 +20,36 @@ from jaxtyping import ArrayLike
 
 
 class MixtureGaussianCDF(AbstractBijection):
-    """Marginal Gaussianization via a mixture of Gaussians CDF.
+    """Marginal Gaussianization via a mixture-of-Gaussians CDF.
 
-    Applies the CDF of a Gaussian mixture model to each dimension independently,
-    mapping the data to uniform, then applies the Gaussian inverse CDF (probit).
+    Maps each dimension independently through its Gaussian-mixture CDF
+    (→ uniform on ``[0, 1]``) then through the inverse normal CDF (probit),
+    giving Gaussianised marginals. Each dim has its own ``n_components`` means,
+    log-scales, and log-weights; scales use a soft floor
+    ``σ = softplus(log_scale) + 5e−3`` for training stability and weights are a
+    softmax over ``log_weights``. The inverse runs a per-dim bisection solver to
+    invert the (monotone) mixture CDF.
+
+    Use as the marginal block of a Gaussianization / RBIG flow. Construct
+    parameters at zero (uniform components) with ``MixtureGaussianCDF(...)``, or
+    data-adapt the means/scales to per-dim quantiles via :meth:`from_data`.
 
     Args:
-        n_components: Number of mixture components per dimension.
-        shape: Shape of the input (n_dims,).
+        n_components: Number of mixture components ``K`` per dimension.
+        shape: Event shape ``(n_dims,)``. Only 1-D events are supported.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import MixtureGaussianCDF
+        >>> t = MixtureGaussianCDF(n_components=4, shape=(3,))
+        >>> x = jnp.zeros(3)
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        (3,)
     """
 
     shape: tuple[int, ...]
@@ -163,13 +185,31 @@ class MixtureGaussianCDF(AbstractBijection):
 
 
 class MixtureLogisticCDF(AbstractBijection):
-    """Marginal Gaussianization via a mixture of logistics CDF.
+    """Marginal Gaussianization via a mixture-of-logistics CDF.
 
-    Similar to MixtureGaussianCDF but uses a logistic mixture.
+    Identical in structure to :class:`MixtureGaussianCDF` but each per-dim
+    mixture component is logistic rather than Gaussian: the component CDF is the
+    sigmoid ``σ((x − μ) / s)``. Maps each dimension through its logistic-mixture
+    CDF (→ uniform on ``[0, 1]``) then through the inverse normal CDF (probit).
+    Scales use the same soft floor ``s = softplus(log_scale) + 5e−3`` and
+    weights are a softmax over ``log_weights``; the inverse uses a per-dim
+    bisection solver.
 
     Args:
-        n_components: Number of mixture components per dimension.
-        shape: Shape of the input (n_dims,).
+        n_components: Number of mixture components ``K`` per dimension.
+        shape: Event shape ``(n_dims,)``. Only 1-D events are supported.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import MixtureLogisticCDF
+        >>> t = MixtureLogisticCDF(n_components=4, shape=(3,))
+        >>> y, log_det = t.transform_and_log_det(jnp.zeros(3))
+        >>> y.shape
+        (3,)
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/spline.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/spline.py
@@ -14,14 +14,33 @@ from jaxtyping import ArrayLike
 
 
 class RQSplineMarginal(AbstractBijection):
-    """Marginal Gaussianization via rational quadratic splines.
+    """Marginal Gaussianization via rational-quadratic splines.
 
-    Applies a rational quadratic spline independently to each dimension.
+    Applies a monotonic rational-quadratic spline (Durkan et al. 2019,
+    *Neural Spline Flows*) independently to each dimension — the elementwise
+    counterpart of :class:`RQSplineCoupling`. Each dim gets its own ``n_bins``
+    knots over the symmetric interval ``[−interval, interval]``; outside that
+    interval the map is the identity (linear tails). Inputs should lie within
+    the interval for the spline to act non-trivially.
 
     Args:
-        n_bins: Number of spline bins.
-        shape: Shape of the input (n_dims,).
-        interval: Interval for the spline. Defaults to 5.0.
+        n_bins: Number of spline knots (bins) per dimension.
+        shape: Event shape ``(n_dims,)``. Only 1-D events are supported.
+        interval: Half-width of the symmetric spline interval
+            ``[−interval, interval]``. Defaults to ``5.0``.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import RQSplineMarginal
+        >>> t = RQSplineMarginal(n_bins=8, shape=(3,), interval=5.0)
+        >>> x = jnp.array([0.1, -0.5, 1.0])  # inside [−5, 5]
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        (3,)
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/linear/conv1x1.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/conv1x1.py
@@ -12,17 +12,40 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 
 
 class Invertible1x1Conv(AbstractBijection):
-    """Invertible 1x1 convolution as used in Glow (https://arxiv.org/abs/1807.03039).
+    """Invertible 1×1 convolution with LU-parameterised weight (Glow).
 
-    Parameterizes an invertible linear mixing across channels/features using
-    an LU decomposition to ensure invertibility and efficient log-det computation.
-    The weight matrix is implicitly W = L @ U where L is lower triangular with
-    unit diagonal and U is upper triangular with positive diagonal (stored as
-    log_diag_u). Log-det is computed cheaply as sum(log_diag_u).
+    Mixes channels/features with an invertible linear map ``y = W·x``,
+    where ``W = L·U`` is stored in LU form: ``L`` is lower-triangular with
+    unit diagonal and ``U`` is upper-triangular with strictly positive
+    diagonal (parameterised as ``exp(log_diag_u)``). This guarantees
+    invertibility and reduces the log-determinant to the cheap
+    ``∑ log_diag_u``, avoiding an explicit Jacobian. Introduced as the 1×1
+    convolution of Glow (Kingma & Dhariwal 2018,
+    https://arxiv.org/abs/1807.03039).
+
+    Operates on a single ``(n_channels,)`` event (the channel/feature
+    vector). Callers vmap over any spatial or batch axes.
 
     Args:
-        key: JAX random key.
-        n_channels: Number of channels/features.
+        key: PRNG key for near-identity initialisation (small off-diagonals).
+        n_channels: Number of channels / feature dimensions.
+
+    Shape:
+        - transform_and_log_det: ``(n_channels,)`` → ``(n_channels,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_channels,)`` → ``(n_channels,)``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import Invertible1x1Conv
+        >>> conv = Invertible1x1Conv(jr.key(0), n_channels=4)
+        >>> x = jr.normal(jr.key(1), (4,))
+        >>> y, log_det = conv.transform_and_log_det(x)
+        >>> y.shape
+        (4,)
+        >>> x_rec, log_det_inv = conv.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-5))
+        True
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/linear/haar.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/haar.py
@@ -10,13 +10,41 @@ from jaxtyping import ArrayLike
 
 
 class HaarWavelet(AbstractBijection):
-    """Haar wavelet transform bijection.
+    """Haar wavelet transform bijection (1-D, last axis).
 
-    Implements the 1D Haar wavelet transform as a bijection. This is used
-    in multi-scale flow architectures to factorize spatial information.
+    Applies the single-level 1-D Haar wavelet transform along the last axis:
+    splits each consecutive even/odd pair into its average and half-difference
+    ``avg = (even + odd)/2``, ``diff = (even − odd)/2``, then concatenates all
+    averages followed by all differences. This factorises an event into a
+    coarse (low-pass) and a detail (high-pass) half, as used in multi-scale
+    flow architectures. Both halves scale by ``1/2``, so the forward
+    log-determinant is the constant ``−n·log 2`` where ``n`` is the size of
+    the last axis.
+
+    Operates on a single event whose last axis is divisible by 2; the
+    transform acts independently along any leading axes.
 
     Args:
-        shape: Shape of the input. The last dimension must be divisible by 2.
+        shape: Event shape. The last dimension must be divisible by 2.
+
+    Raises:
+        ValueError: If the last dimension of ``shape`` is not divisible by 2.
+
+    Shape:
+        - transform_and_log_det: ``(…, n)`` → ``(…, n)``, scalar log_det = −n·log 2
+        - inverse_and_log_det:   ``(…, n)`` → ``(…, n)``, scalar log_det = +n·log 2
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import HaarWavelet
+        >>> t = HaarWavelet(shape=(4,))
+        >>> x = jnp.array([1.0, 3.0, 5.0, 9.0])
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y  # [avg0, avg1, diff0, diff1]
+        Array([ 2.,  7., -1., -2.], dtype=float32)
+        >>> x_rec, _ = t.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec))
+        True
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/linear/lu.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/lu.py
@@ -19,12 +19,34 @@ class LULinearPermute(AbstractBijection):
 
     Cheaper than :class:`OrthogonalRotation` in the relevant regime (no Cayley
     solve at forward / inverse time) and widely used as the mixing layer in
-    Neural Spline Flows (Durkan et al. 2019).
+    Neural Spline Flows (Durkan et al. 2019, *Neural Spline Flows*).
+
+    Operates on a single ``(n_dims,)`` event; callers vmap over any batch axis.
 
     Args:
-        shape: Shape of the input ``(n_dims,)``.
+        shape: Event shape ``(n_dims,)``. Only 1-D events are supported.
         permutation: Optional permutation of length ``n_dims``. Defaults to the
-            reverse permutation.
+            reverse permutation ``[n_dims−1, …, 1, 0]``.
+
+    Raises:
+        ValueError: If ``shape`` is not 1-D, or ``permutation`` is not a valid
+            permutation of ``0..n_dims−1`` with the right shape.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import LULinearPermute
+        >>> t = LULinearPermute(shape=(3,))  # reverse permutation
+        >>> x = jnp.array([1.0, 2.0, 3.0])
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        (3,)
+        >>> x_rec, log_det_inv = t.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-5))
+        True
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/linear/rotation.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/rotation.py
@@ -16,15 +16,41 @@ def _householder(x: Array, v: Array) -> Array:
 
 
 class HouseholderRotation(AbstractBijection):
-    """Rotation via a sequence of Householder reflections.
+    """Orthogonal rotation via a sequence of Householder reflections.
 
-    Stacks multiple Householder reflections to produce a general orthogonal
-    transformation. When n_reflections == dim, this can represent any orthogonal
-    matrix.
+    Composes ``n_reflections`` Householder reflections — each of the form
+    ``x ↦ x − 2·(x·v̂)·v̂`` with unit vector ``v̂`` — to build a general
+    orthogonal map. With ``n_reflections == n_dims`` this can represent any
+    orthogonal matrix. Each reflection is its own inverse, so the inverse
+    simply applies the reflections in reverse order. Being orthogonal, the map
+    is volume-preserving and ``log_det = 0`` exactly.
+
+    Operates on a single ``(n_dims,)`` event; callers vmap over any batch axis.
 
     Args:
         n_reflections: Number of Householder reflections to compose.
-        shape: Shape of the input (n_dims,).
+        shape: Event shape ``(n_dims,)``. Only 1-D events are supported.
+
+    Raises:
+        ValueError: If ``shape`` is not 1-D.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import HouseholderRotation
+        >>> t = HouseholderRotation(n_reflections=2, shape=(3,))
+        >>> x = jnp.array([1.0, 2.0, 3.0])
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        (3,)
+        >>> bool(jnp.allclose(log_det, 0.0))
+        True
+        >>> x_rec, _ = t.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-5))
+        True
     """
 
     shape: tuple[int, ...]
@@ -56,13 +82,37 @@ class HouseholderRotation(AbstractBijection):
 
 
 class OrthogonalRotation(AbstractBijection):
-    """Rotation via a learnable orthogonal matrix using Cayley parameterization.
+    """Learnable orthogonal rotation via the Cayley map.
 
-    Uses the Cayley map to parameterize orthogonal matrices via skew-symmetric
-    matrices: Q = (I - A)(I + A)^{-1}, where A is skew-symmetric.
+    Parameterises an orthogonal matrix ``Q = (I − A)(I + A)⁻¹`` from a
+    skew-symmetric ``A`` (built from the ``n_dims·(n_dims−1)/2`` strictly
+    lower-triangular free parameters, then antisymmetrised). The Cayley
+    transform maps any skew-symmetric ``A`` to a special orthogonal ``Q``,
+    so the map ``y = Q·x`` is volume-preserving with ``log_det = 0`` exactly.
+    Initialised at ``A = 0`` (``Q = I``), i.e. the identity at step 0.
+
+    Operates on a single ``(n_dims,)`` event; callers vmap over any batch axis.
 
     Args:
-        shape: Shape of the input (n_dims,).
+        shape: Event shape ``(n_dims,)``. Only 1-D events are supported.
+
+    Raises:
+        ValueError: If ``shape`` is not 1-D.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import OrthogonalRotation
+        >>> t = OrthogonalRotation(shape=(3,))  # Q = I at init
+        >>> x = jnp.array([1.0, 2.0, 3.0])
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> bool(jnp.allclose(y, x))  # identity at zero init
+        True
+        >>> bool(jnp.allclose(log_det, 0.0))
+        True
     """
 
     shape: tuple[int, ...]
@@ -101,21 +151,45 @@ class OrthogonalRotation(AbstractBijection):
 
 
 class FixedRotation(AbstractBijection):
-    """A fixed (non-trainable) rotation matrix.
+    """Fixed (non-trainable) orthogonal rotation matrix.
 
-    Useful when the rotation is pre-computed (e.g. via PCA) and should
-    not be updated during training.
+    Applies a pre-computed orthogonal matrix ``y = matrix·x`` (e.g. a PCA
+    rotation from :meth:`from_data`) that is held constant during training.
+    Orthogonality makes the map volume-preserving, so ``log_det = 0`` exactly
+    and the inverse is the transpose.
 
-    The orthogonal matrix is stored internally wrapped in
-    :class:`paramax.NonTrainable` so ``flowjax.train.fit_to_data`` skips it
-    during gradient descent — without the wrapper Adam drifts the rows off
-    the orthogonal manifold and sampling silently collapses while
-    ``log_prob`` keeps reporting plausible numbers. The public ``matrix``
-    attribute transparently returns the unwrapped :class:`jax.Array` so
-    downstream code can still do ``rot.matrix @ x`` unchanged.
+    The matrix is stored wrapped in :class:`paramax.NonTrainable` so
+    ``flowjax.train.fit_to_data`` skips it during gradient descent — without
+    the wrapper Adam drifts the rows off the orthogonal manifold and sampling
+    silently collapses while ``log_prob`` keeps reporting plausible numbers.
+    The public ``matrix`` property transparently returns the unwrapped
+    :class:`jax.Array` so downstream code can still do ``rot.matrix @ x``.
+
+    Operates on a single ``(n_dims,)`` event; callers vmap over any batch axis.
 
     Args:
         matrix: Orthogonal rotation matrix of shape ``(n_dims, n_dims)``.
+
+    Raises:
+        ValueError: If ``matrix`` is not a square 2-D array.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import FixedRotation
+        >>> Q, _ = jnp.linalg.qr(jr.normal(jr.key(0), (3, 3)))
+        >>> t = FixedRotation(Q)
+        >>> x = jnp.array([1.0, 2.0, 3.0])
+        >>> y, log_det = t.transform_and_log_det(x)
+        >>> y.shape
+        (3,)
+        >>> x_rec, _ = t.inverse_and_log_det(y)
+        >>> bool(jnp.allclose(x, x_rec, atol=1e-5))
+        True
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/normalization/actnorm.py
+++ b/src/gauss_flows/_src/transforms/bijections/normalization/actnorm.py
@@ -17,13 +17,31 @@ from jaxtyping import ArrayLike
 
 
 class ActNorm(AbstractBijection):
-    """Activation normalization (ActNorm).
+    """Activation normalization (ActNorm) for image-shaped events.
 
-    Performs per-channel normalization with learnable location and scale.
-    For images, operates on the channel dimension.
+    Per-channel affine normalization with learnable location ``loc`` and
+    positive scale ``softplus(log_scale) + 1e-5``. The scale and location are
+    indexed by the trailing (channel) axis and broadcast across any leading
+    spatial axes, so the log-det of a single event is the per-channel log-scale
+    sum multiplied by the number of spatial positions. Introduced as a
+    replacement for batch normalization in Glow (Kingma & Dhariwal 2018).
 
     Args:
-        shape: Shape of the input.
+        shape: Event shape ``(..., C)``; the last axis is the channel axis.
+            For example ``(H, W, C)`` for an image or ``(C,)`` for a plain
+            channel vector.
+
+    Shape:
+        - transform_and_log_det: ``(..., C)`` → ``(..., C)``, scalar log_det
+        - inverse_and_log_det:   ``(..., C)`` → ``(..., C)``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import ActNorm
+        >>> layer = ActNorm(shape=(4, 4, 3))
+        >>> y, log_det = layer.transform_and_log_det(jnp.ones((4, 4, 3)))
+        >>> y.shape, log_det.shape
+        ((4, 4, 3), ())
     """
 
     shape: tuple[int, ...]
@@ -59,14 +77,31 @@ class ActNorm(AbstractBijection):
 
 
 class ActNorm1D(AbstractBijection):
-    """Activation normalization for 1D inputs.
+    """Activation normalization (ActNorm) for 1-D events.
 
-    Performs per-dimension affine transformation with learnable location and
-    log-scale parameters. Similar to batch normalization but with learned
-    parameters that are not data-dependent at inference time.
+    The 1-D specialisation of :class:`ActNorm` used inside the coupling-flow
+    stack where there are no spatial axes. Applies a per-dimension affine map
+    ``y = (x − loc) / scale`` with positive ``scale = softplus(log_scale) +
+    1e-5``. Unlike batch normalization, the parameters are learned and not
+    data-dependent at inference time (Kingma & Dhariwal 2018).
 
     Args:
-        shape: Shape of the input (n_dims,).
+        shape: Event shape ``(n_dims,)``. Must be 1-D.
+
+    Raises:
+        ValueError: If ``shape`` is not 1-D.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import ActNorm1D
+        >>> layer = ActNorm1D(shape=(3,))
+        >>> y, log_det = layer.transform_and_log_det(jnp.ones((3,)))
+        >>> y.shape, log_det.shape
+        ((3,), ())
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/normalization/batchnorm.py
+++ b/src/gauss_flows/_src/transforms/bijections/normalization/batchnorm.py
@@ -42,13 +42,34 @@ class BatchNorm(AbstractBijection):
     explicitly instead of mutating in place.
 
     Args:
-        shape: Input shape ``(n_dims,)``.
+        shape: Event shape ``(n_dims,)``. Must be 1-D.
         momentum: Exponential moving-average factor for running statistics,
             updated as ``running = (1 - momentum) * running + momentum * batch``.
-        eps: Numerical stability term added to the variance.
-        use_running_average: Whether to use running statistics (evaluation).
+            Must lie in ``(0, 1)``. Defaults to ``0.1``.
+        eps: Numerical stability term added to the variance. Defaults to
+            ``1e-5``.
+        use_running_average: Whether to use running statistics (evaluation)
+            rather than batch statistics. Defaults to ``False``.
+
+    Raises:
+        ValueError: If ``shape`` is not 1-D or ``momentum`` is outside
+            ``(0, 1)``.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
     Example:
+        >>> import jax
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> from gauss_flows import BatchNorm
+        >>> batch = jr.normal(jr.key(0), (8, 2))
+        >>> bn = BatchNorm(shape=(2,)).with_batch_stats_from_data(batch)
+        >>> y, log_det = bn.transform_and_log_det(batch[0])
+        >>> y.shape, log_det.shape
+        ((2,), ())
+
         Training step pattern (per batch)::
 
             @eqx.filter_value_and_grad

--- a/src/gauss_flows/_src/transforms/bijections/periodic/_utils.py
+++ b/src/gauss_flows/_src/transforms/bijections/periodic/_utils.py
@@ -24,6 +24,7 @@ def _wrap_angles(x: Array, mask: Array, bound: float) -> Array:
 
 
 def _build_periodic_mask(ind: tuple[int, ...], n_dims: int) -> Array:
+    """Boolean mask of length ``n_dims`` that is True at the periodic indices."""
     mask = jnp.zeros(n_dims, dtype=bool)
     if ind:
         mask = mask.at[jnp.array(ind)].set(True)

--- a/src/gauss_flows/_src/transforms/bijections/periodic/shift.py
+++ b/src/gauss_flows/_src/transforms/bijections/periodic/shift.py
@@ -18,24 +18,34 @@ from gauss_flows._src.transforms.bijections.periodic._utils import (
 class PeriodicShift(AbstractBijection):
     """Learnable circular shift on selected periodic dimensions.
 
-    Adds a learnable per-index offset and re-wraps into ``[-bound, bound]``.
-    Determinant is 1, so ``log_det = 0``.
-
-    Shape:
-        Input/output: ``(D,)`` (single event). ``log_det`` is a scalar ``Array``.
+    Adds a learnable per-index offset to the chosen dimensions and re-wraps the
+    result back into ``[−bound, bound]``. The map is a translation on the
+    circle, so its Jacobian determinant is 1 and ``log_det = 0``. Non-periodic
+    dimensions pass through unchanged.
 
     Args:
-        ind: Indices of periodic dimensions to shift.
-        shape: Event shape, must be 1D.
+        ind: Indices of periodic dimensions to shift. Must be unique and lie in
+            ``[0, n_dims)``.
+        shape: Event shape ``(n_dims,)``. Must be 1-D.
         bound: Half-width of the periodic interval. Defaults to ``π``.
-        shift_init: Optional initial shift. Either a scalar (broadcast to every
-            index) or a 1D array of length ``len(ind)``.
+        shift_init: Initial shift. Either a scalar (broadcast to every index) or
+            a 1-D array of length ``len(ind)``. Defaults to ``0.0``.
+
+    Raises:
+        ValueError: If ``shape`` is not 1-D, if any index is out of range or
+            duplicated, or if ``shift_init`` has an incompatible shape.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
     Example:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import PeriodicShift
         >>> shift = PeriodicShift(ind=(0,), shape=(2,), shift_init=0.25)
         >>> y, log_det = shift.transform_and_log_det(jnp.array([1.0, 0.5]))
+        >>> y.shape, float(log_det)
+        ((2,), 0.0)
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/periodic/wrap.py
+++ b/src/gauss_flows/_src/transforms/bijections/periodic/wrap.py
@@ -16,34 +16,45 @@ from gauss_flows._src.transforms.bijections.periodic._utils import (
 
 
 class PeriodicWrap(AbstractBijection):
-    """Canonical projection of selected dimensions onto ``[-bound, bound]``.
+    """Canonical projection of selected dimensions onto ``[−bound, bound]``.
+
+    Wraps the chosen periodic dimensions into the canonical interval
+    ``[−bound, bound]`` and leaves all other dimensions untouched.
 
     .. warning::
         This subclasses ``flowjax.bijections.AbstractBijection`` for API
-        compatibility but is **not a true bijection on R** — it is a many-to-one
-        canonical projection. ``x`` and ``x + 2·bound·k`` collapse to the same
-        canonical value, and ``inverse_and_log_det`` returns that same wrapped
-        value (not the original ``x``) with ``log_det = 0``. Composing this
-        inside a ``flowjax.distributions.Transformed`` or ``SurVAEFlow`` will
-        give **incorrect log-densities** if the upstream samples are not already
-        in ``[-bound, bound]``, because the change-of-variables formula assumes
-        invertibility. Use this layer only as a leading-edge canonicaliser for
-        raw angles, never as an inner layer in a density model.
-
-    Shape:
-        Input/output: ``(D,)`` (single event). ``log_det`` is a scalar ``Array``.
+        compatibility but is **not a true bijection on ℝ** — it is a
+        many-to-one canonical projection. ``x`` and ``x + 2·bound·k`` collapse
+        to the same canonical value, and ``inverse_and_log_det`` returns that
+        same wrapped value (not the original ``x``) with ``log_det = 0``.
+        Composing this inside a ``flowjax.distributions.Transformed`` or
+        ``SurVAEFlow`` will give **incorrect log-densities** if the upstream
+        samples are not already in ``[−bound, bound]``, because the
+        change-of-variables formula assumes invertibility. Use this layer only
+        as a leading-edge canonicaliser for raw angles, never as an inner layer
+        in a density model.
 
     Args:
-        ind: Indices of periodic dimensions to wrap.
-        shape: Event shape, must be 1D.
+        ind: Indices of periodic dimensions to wrap. Must lie in
+            ``[0, n_dims)``.
+        shape: Event shape ``(n_dims,)``. Must be 1-D.
         bound: Half-width of the periodic interval. Defaults to ``π``.
+
+    Raises:
+        ValueError: If ``shape`` is not 1-D or any index is out of range.
+
+    Shape:
+        - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+        - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
+          (returns the wrapped value, not the original ``x``; see warning)
 
     Example:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import PeriodicWrap
         >>> wrap = PeriodicWrap(ind=(0,), shape=(2,))
         >>> y, log_det = wrap.transform_and_log_det(jnp.array([3.5, 0.2]))
-        >>> # y[0] is in [-π, π); y[1] is unchanged.
+        >>> bool(y[0] >= -jnp.pi and y[0] < jnp.pi)  # dim 0 wrapped; dim 1 kept
+        True
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/reshape/squeeze.py
+++ b/src/gauss_flows/_src/transforms/bijections/reshape/squeeze.py
@@ -10,13 +10,39 @@ from jaxtyping import ArrayLike
 
 
 class Squeeze(AbstractBijection):
-    """Squeeze operation for image-like inputs.
+    """Volume-preserving squeeze that trades spatial extent for channels.
 
-    Reshapes spatial dimensions into channels, halving the spatial resolution
-    and quadrupling the channels. Commonly used in multi-scale flow architectures.
+    Reshapes a single event so that resolution along the leading axis is halved
+    and the trailing (channel) axis is correspondingly enlarged, exposing more
+    structure to subsequent channel-wise layers. The map is a pure reshape, so
+    it is exactly invertible and volume-preserving (``log_det = 0``). Commonly
+    used to build multi-scale normalizing-flow architectures (Dinh et al. 2017).
+
+    Three regimes by rank of ``shape``:
+
+    - 1-D ``(n,)`` with ``n`` even → ``(n // 2, 2)``: split into adjacent pairs.
+    - 2-D ``(H, C)`` with ``H`` even → ``(H // 2, 2·C)``: fold pairs of rows
+      into the channel axis.
+    - Higher rank: pass through unchanged (identity reshape).
 
     Args:
-        shape: Shape of the input (H, W, C) or (N, C).
+        shape: Event shape ``(n,)`` or ``(H, C)``; the leading axis must be even
+            in those two cases. Higher-rank shapes are accepted but unchanged.
+
+    Raises:
+        ValueError: If the leading axis of a 1-D or 2-D ``shape`` is not even.
+
+    Shape:
+        - transform_and_log_det: ``shape`` → ``out_shape``, scalar log_det (0)
+        - inverse_and_log_det:   ``out_shape`` → ``shape``, scalar log_det (0)
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gauss_flows import Squeeze
+        >>> layer = Squeeze(shape=(4, 3))
+        >>> y, log_det = layer.transform_and_log_det(jnp.ones((4, 3)))
+        >>> y.shape, float(log_det)
+        ((2, 6), 0.0)
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/surjections/pool.py
+++ b/src/gauss_flows/_src/transforms/surjections/pool.py
@@ -52,14 +52,17 @@ class SimpleMaxPoolSurjection2d(AbstractSurjection):
         - ``log_det``:   scalar (shape ``()``)
 
     Example:
-        >>> import jax.numpy as jnp
-        >>> import jax.random as jr
-        >>> from gauss_flows import SimpleMaxPoolSurjection2d
-        >>>
-        >>> # ``my_decoder`` must implement the ConditionalDistribution
-        >>> # protocol — see _src/_protocols.py.
-        >>> surj = SimpleMaxPoolSurjection2d((8, 8, 3), my_decoder, pool_size=2)
-        >>> # z.shape == (4, 4, 3); residuals.shape == (4, 4, 3, 3) (pool_area-1).
+        ``my_decoder`` must implement the :class:`ConditionalDistribution`
+        protocol (see ``_src/_protocols.py``); it maps a pooled image
+        ``z`` of shape ``(4, 4, 3)`` to residuals of shape ``(4, 4, 3, 3)``::
+
+            import jax.numpy as jnp
+            import jax.random as jr
+            from gauss_flows import SimpleMaxPoolSurjection2d
+
+            surj = SimpleMaxPoolSurjection2d((8, 8, 3), my_decoder, pool_size=2)
+            z, log_det = surj.forward_and_log_det(jnp.zeros((8, 8, 3)), jr.key(0))
+            # z.shape == (4, 4, 3); residuals.shape == (4, 4, 3, 3) (pool_area-1).
     """
 
     stochastic_forward: ClassVar[bool] = False


### PR DESCRIPTION
## Why

Overhaul the documentation to match the polished structure of the `geonnax` repo, while
respecting `gauss_flows`' own conventions. The previous API reference was a single flat
`::: gauss_flows` dump and several public docstrings were stubs missing `Shape:`/`Example:`
sections and type annotations.

## Part A — docs site structure

- **`mkdocs.yml`**: mkdocstrings options upgraded to match geonnax (section tables,
  symbol-type headings + TOC, signature crossrefs, `members_order: source`,
  `filters: ["!^_"]`, `heading_level: 3`); API nav split into themed pages + a Changelog link.
- **`docs/api/`**: replaced the flat reference with an **Overview + 6 themed pages**
  (bijections, surjections, distributions, flows, inference, info_theory), each with a
  prose+math intro and per-symbol `:::` directives.
- **`README.md` / `docs/index.md`**: badge row, "What's inside" table, single-event
  quickstart, themed API links. Install from source (not yet on PyPI).

## Part B — uniform docstrings + missing type hints

- Every public symbol's docstring normalised to one template: one-line summary →
  math/intuition → `Args:`/`Returns:`/`Raises:` → `Shape:` (single-event convention; scalar
  `log_det`; callers vmap) → a runnable `Example:` block. Most examples are deterministic
  `>>>` doctests; slow training/MC/ODE examples are illustrative blocks.
- Added the type annotations griffe flagged as missing (`FlowGuide.__init__` params,
  `fit_gaussianization_flow`'s return) and `from __future__ import annotations` to
  `numpyro_guide.py` / `train.py`.
- **Documentation-only** — no logic, names, defaults, or control flow changed.

## Peculiarities respected

- Kept the `.ipynb`-only notebook workflow (no jupytext/Colab/watermark like geonnax).
- Preserved the single-event transform convention and Unicode-math docstrings.
- Pointed the Changelog nav at the GitHub URL (a root `CHANGELOG.md` in nav doesn't resolve
  under `docs/`), and skipped a PyPI badge since the package isn't published.

## Verification

- `ruff format --check .` + `ruff check .` — clean
- `ty check src/gauss_flows` — clean
- Doctest sweep across all 37 changed source files — **0 failures**
- `mkdocs build` — **0 griffe warnings, no broken links** (was 13)
- `pytest -m "not slow and not integration"` — **411 passed, 90.21% coverage**

https://claude.ai/code/session_01KSt4pcUNbRFb2ZRgrW7oFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSt4pcUNbRFb2ZRgrW7oFX)_