### PR TITLE
docs: fix mkdocstrings rendering of examples and math; add render guard test

### DIFF
--- a/src/gauss_flows/_src/_protocols.py
+++ b/src/gauss_flows/_src/_protocols.py
@@ -3,8 +3,8 @@
 These ``Protocol`` definitions describe the minimal duck-typed interfaces that
 SurVAE-style transforms (and their tests) need from a "conditional
 distribution" object — without forcing inheritance from any concrete base
-class. Concrete implementations can come from :mod:`numpyro.distributions`,
-:mod:`flowjax.distributions` (via thin wrappers), or user code.
+class. Concrete implementations can come from `numpyro.distributions`,
+`flowjax.distributions` (via thin wrappers), or user code.
 """
 
 from __future__ import annotations

--- a/src/gauss_flows/_src/conditioning.py
+++ b/src/gauss_flows/_src/conditioning.py
@@ -35,7 +35,7 @@ def pack_time_control(
         Packed condition with shape ``(..., 1 + C)`` — or ``(..., 1)`` when
         ``control`` is ``None``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import pack_time_control
         >>> pack_time_control(0.5).shape
@@ -73,7 +73,7 @@ def unpack_time_control(
         A tuple ``(t, control)`` where ``t`` has shape ``(..., 1)`` and
         ``control`` has shape ``(..., control_dim)`` or is ``None``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import unpack_time_control
         >>> t, control = unpack_time_control(jnp.array([0.5, 1.0, 2.0]), control_dim=2)
@@ -108,7 +108,7 @@ def time_control_cond_shape(control_dim: int = 0) -> tuple[int, ...]:
     Returns:
         A one-tuple ``(1 + control_dim,)`` suitable for ``AbstractBijection``.
 
-    Example:
+    Examples:
         >>> from gauss_flows import time_control_cond_shape
         >>> time_control_cond_shape()
         (1,)

--- a/src/gauss_flows/_src/distributions/class_cond_diag_gaussian.py
+++ b/src/gauss_flows/_src/distributions/class_cond_diag_gaussian.py
@@ -48,7 +48,7 @@ class ClassCondDiagGaussian(AbstractDistribution):
         ``ClassCondDiagGaussian(key, n_classes=10, event_shape=(D,),
         learn_mean=False, logscale_factor=3.0)``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import ClassCondDiagGaussian

--- a/src/gauss_flows/_src/distributions/conditional_diag_gaussian.py
+++ b/src/gauss_flows/_src/distributions/conditional_diag_gaussian.py
@@ -22,16 +22,16 @@ class ConditionalDiagGaussian(AbstractDistribution):
     The parameter network maps a 1-D context vector
     ``condition: (cond_dim,)`` to ``(2 * event_dim,)`` outputs which are then
     split (along the last axis) into ``loc`` and ``log_scale``. This mirrors
-    the coupling-net pattern used by :class:`AffineCoupling` and avoids the
+    the coupling-net pattern used by `AffineCoupling` and avoids the
     duplication of two parallel sub-networks.
 
     Args:
-        key: PRNG key used to initialise the default :class:`equinox.nn.MLP`.
+        key: PRNG key used to initialise the default `equinox.nn.MLP`.
             Ignored when a pre-built ``param_net`` is supplied.
         event_shape: Single-event shape ``(D,)``. 1-D only.
         cond_shape: Condition shape ``(cond_dim,)``. 1-D only.
         param_net: Optional pre-built callable ``(cond_dim,) -> (2 * D,)``.
-            If omitted, a default :class:`equinox.nn.MLP` is built using
+            If omitted, a default `equinox.nn.MLP` is built using
             ``nn_width`` / ``nn_depth`` / ``activation``.
         nn_width: Width of the default MLP.
         nn_depth: Depth of the default MLP.
@@ -42,7 +42,7 @@ class ConditionalDiagGaussian(AbstractDistribution):
         - Sample / log_prob input: ``(D,)``
         - log_prob output: scalar ``()``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import ConditionalDiagGaussian

--- a/src/gauss_flows/_src/distributions/mixture.py
+++ b/src/gauss_flows/_src/distributions/mixture.py
@@ -1,6 +1,6 @@
 """Trainable Gaussian mixture base distribution.
 
-Natural companion to :class:`MixtureGaussianCDF` (the marginal transform):
+Natural companion to `MixtureGaussianCDF` (the marginal transform):
 provides a joint multi-modal base for Gaussianization pipelines on targets
 that are multi-modal or fat-tailed.
 """
@@ -31,7 +31,7 @@ class GaussianMixture(AbstractDistribution):
     one (a per-component lower-triangular Cholesky factor).
 
     Use as a flow base when the Gaussianized target is multi-modal or
-    fat-tailed — the natural companion to :class:`MixtureGaussianCDF`,
+    fat-tailed — the natural companion to `MixtureGaussianCDF`,
     the per-dimension marginal transform.
 
     Args:
@@ -55,7 +55,7 @@ class GaussianMixture(AbstractDistribution):
         - log_prob: ``(D,)`` → scalar    (batch via vmap / leading axes)
         - sample:   ``(key, sample_shape)`` → ``(*sample_shape, D)``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import GaussianMixture

--- a/src/gauss_flows/_src/distributions/numpyro_base.py
+++ b/src/gauss_flows/_src/distributions/numpyro_base.py
@@ -11,7 +11,7 @@ from jaxtyping import PRNGKeyArray
 
 
 class NumpyroBase(AbstractDistribution):
-    """Wrap any :class:`numpyro.distributions.Distribution` as a flowjax base.
+    """Wrap any `numpyro.distributions.Distribution` as a flowjax base.
 
     Two construction modes:
 
@@ -32,7 +32,7 @@ class NumpyroBase(AbstractDistribution):
     Vector events: numpyro returns one log-prob per *event-shape* position
     by default. Wrap your distribution in ``.to_event(rank)`` so that
     ``log_prob`` returns a scalar; alternatively, use a multivariate
-    distribution like :class:`numpyro.distributions.MultivariateNormal` whose
+    distribution like `numpyro.distributions.MultivariateNormal` whose
     ``event_shape`` already encodes the rank.
 
     Args:
@@ -48,7 +48,7 @@ class NumpyroBase(AbstractDistribution):
         - Sample / log_prob input: ``event_shape``
         - log_prob output: scalar ``()``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> import numpyro.distributions as ndist

--- a/src/gauss_flows/_src/distributions/pca.py
+++ b/src/gauss_flows/_src/distributions/pca.py
@@ -1,7 +1,7 @@
 """Probabilistic-PCA base distribution (low-rank + diagonal Gaussian).
 
 Parameterises ``Sigma = W W^T + sigma^2 I`` with ``W in R^{D x K}`` via
-:class:`GaussianPCA`. ``O(DK)`` parameters and ``O(DK)`` sampling via the
+`GaussianPCA`. ``O(DK)`` parameters and ``O(DK)`` sampling via the
 reparametrisation ``x = loc + W z + sigma eps``. Log-prob uses the
 Woodbury identity / matrix-determinant lemma so inversion and
 log-determinant stay ``O(K^3)`` + ``O(DK)`` rather than ``O(D^3)``.
@@ -54,7 +54,7 @@ class GaussianPCA(AbstractDistribution):
         - log_prob: ``(D,)`` → scalar    (batch via vmap / leading axes)
         - sample:   ``(key, sample_shape)`` → ``(*sample_shape, D)``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import GaussianPCA

--- a/src/gauss_flows/_src/distributions/sphere.py
+++ b/src/gauss_flows/_src/distributions/sphere.py
@@ -126,7 +126,7 @@ class UniformOnSphere(AbstractDistribution):
         - log_prob: ``(d+1,)`` → scalar    (batch via vmap / leading axes)
         - sample:   ``(key, sample_shape)`` → ``(*sample_shape, d+1)``
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import UniformOnSphere
         >>> dist = UniformOnSphere(d=2)
@@ -162,7 +162,7 @@ class VonMisesFisher(AbstractDistribution):
 
     Density ``p(x) ∝ exp(κ · μᵀx)`` on the sphere: the spherical analogue of
     an isotropic Gaussian, peaked at the mean direction ``μ`` with
-    concentration ``κ`` (``κ = 0`` recovers :class:`UniformOnSphere`). The
+    concentration ``κ`` (``κ = 0`` recovers `UniformOnSphere`). The
     normaliser involves a modified Bessel function ``I_ν(κ)``, evaluated
     here via a hybrid power-series / asymptotic expansion. Sampling uses
     Wood's (1994) rejection scheme. Useful as a flow base for concentrated
@@ -183,7 +183,7 @@ class VonMisesFisher(AbstractDistribution):
         - log_prob: ``(d+1,)`` → scalar    (batch via vmap / leading axes)
         - sample:   ``(key, sample_shape)`` → ``(*sample_shape, d+1)``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import VonMisesFisher

--- a/src/gauss_flows/_src/flows/__init__.py
+++ b/src/gauss_flows/_src/flows/__init__.py
@@ -1,8 +1,8 @@
-"""Flow constructors and the :class:`SurVAEFlow` container.
+"""Flow constructors and the `SurVAEFlow` container.
 
-- :mod:`.survae` holds the bijection/surjection chain container.
-- :mod:`.gaussianization` holds the RBIG-style flow factories.
-- :mod:`.rbig` holds the classic iterative-RBIG constructor.
+- `.survae` holds the bijection/surjection chain container.
+- `.gaussianization` holds the RBIG-style flow factories.
+- `.rbig` holds the classic iterative-RBIG constructor.
 """
 
 from gauss_flows._src.flows.class_cond_flow import ClassCondFlow

--- a/src/gauss_flows/_src/flows/class_cond_flow.py
+++ b/src/gauss_flows/_src/flows/class_cond_flow.py
@@ -18,11 +18,11 @@ from gauss_flows._src.transforms.base import AbstractSurjection
 
 
 class ClassCondFlow(eqx.Module):
-    """Class-conditional flow built on a :class:`ClassCondDiagGaussian` base.
+    """Class-conditional flow built on a `ClassCondDiagGaussian` base.
 
-    A thin convenience wrapper around :class:`SurVAEFlow` that:
+    A thin convenience wrapper around `SurVAEFlow` that:
 
-    - constructs a :class:`ClassCondDiagGaussian` base with the given
+    - constructs a `ClassCondDiagGaussian` base with the given
       ``n_classes`` and ``event_shape``;
     - exposes a ``label`` keyword in its public API (instead of the more
       generic ``condition``) for ergonomics in the class-conditional case;
@@ -34,7 +34,7 @@ class ClassCondFlow(eqx.Module):
     condition that the base requires for index lookup), which is incompatible
     with the ``(cond_dim,)``-shaped condition that conditional couplings
     expect. If you want conditional transforms in addition to a class-
-    conditional base, build a :class:`SurVAEFlow` directly and pack a
+    conditional base, build a `SurVAEFlow` directly and pack a
     label-derived feature vector (e.g. one-hot) into a custom condition;
     this wrapper deliberately does not support that to keep the contract
     simple.
@@ -46,14 +46,14 @@ class ClassCondFlow(eqx.Module):
         transforms: Sequence of unconditional bijections / surjections,
             applied left-to-right in the base→data direction. Conditional
             transforms (``cond_shape != None``) are rejected at construction.
-        learn_mean: Forwarded to :class:`ClassCondDiagGaussian`.
-        logscale_factor: Forwarded to :class:`ClassCondDiagGaussian`.
+        learn_mean: Forwarded to `ClassCondDiagGaussian`.
+        logscale_factor: Forwarded to `ClassCondDiagGaussian`.
 
     Shape:
         - ``label``: scalar int (``cond_shape == ()``)
         - ``x`` / ``y``: ``event_shape``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import ClassCondFlow, AffineCoupling

--- a/src/gauss_flows/_src/flows/gaussianization.py
+++ b/src/gauss_flows/_src/flows/gaussianization.py
@@ -38,8 +38,8 @@ def gaussianization_flow(
     LU-parametrised linear). Mixture means and Householder vectors are
     randomly initialised to break symmetry so gradient training has a
     signal to separate the components. The block stack is composed with a
-    memory-efficient :class:`flowjax.bijections.Scan` and wrapped in a
-    base :class:`~flowjax.distributions.Normal`.
+    memory-efficient `flowjax.bijections.Scan` and wrapped in a
+    base `flowjax.distributions.Normal`.
 
     Args:
         key: JAX random key.
@@ -63,7 +63,7 @@ def gaussianization_flow(
         ValueError: If ``base_dist`` has the wrong event shape, is
             conditional, or ``rotation`` is not a recognised name.
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import gaussianization_flow
         >>> flow = gaussianization_flow(jr.key(0), n_dims=4, n_layers=4, n_components=8)
@@ -136,13 +136,13 @@ def coupling_gaussianization_flow(
 
     Stacks ``n_layers`` alternating C∘P blocks, where each block is a
     rational-quadratic-spline coupling layer C followed by a permutation P
-    (a :class:`~flowjax.bijections.Flip` for ``n_dims == 2``, a random
-    :class:`~flowjax.bijections.Permute` otherwise; no permutation for
-    ``n_dims == 1``). Unlike :func:`gaussianization_flow`, the coupling
+    (a `flowjax.bijections.Flip` for ``n_dims == 2``, a random
+    `flowjax.bijections.Permute` otherwise; no permutation for
+    ``n_dims == 1``). Unlike `gaussianization_flow`, the coupling
     conditioner lets each layer represent non-linear, cross-coordinate
     transformations. The block stack is composed with
-    :class:`flowjax.bijections.Scan` and wrapped in a base
-    :class:`~flowjax.distributions.Normal`.
+    `flowjax.bijections.Scan` and wrapped in a base
+    `flowjax.distributions.Normal`.
 
     Args:
         key: JAX random key.
@@ -158,7 +158,7 @@ def coupling_gaussianization_flow(
     Returns:
         A flowjax ``Transformed`` distribution with ``log_prob`` and ``sample``.
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import coupling_gaussianization_flow
         >>> flow = coupling_gaussianization_flow(jr.key(0), n_dims=4, n_layers=2)

--- a/src/gauss_flows/_src/flows/rbig.py
+++ b/src/gauss_flows/_src/flows/rbig.py
@@ -22,7 +22,7 @@ def iterative_rbig(
     Implements the classic RBIG algorithm as a normalizing flow: each of
     ``n_layers`` iterations alternates a marginal Gaussianization step G
     with a rotation R (the G∘R block). This is a thin wrapper around
-    :func:`~gauss_flows.gaussianization_flow` with a large default
+    `gauss_flows.gaussianization_flow` with a large default
     ``n_layers`` reflecting the many shallow iterations RBIG typically
     uses; all arguments are forwarded unchanged.
 
@@ -39,7 +39,7 @@ def iterative_rbig(
     Returns:
         A flowjax ``Transformed`` distribution with ``log_prob`` and ``sample``.
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import iterative_rbig
         >>> flow = iterative_rbig(jr.key(0), n_dims=4, n_layers=3, n_components=4)

--- a/src/gauss_flows/_src/flows/survae.py
+++ b/src/gauss_flows/_src/flows/survae.py
@@ -27,7 +27,7 @@ def _to_data(
     direction (its "sample" side), while SurVAE's
     ``AbstractSurjection.inverse_and_log_det`` is the latent -> data
     direction (latent ≡ base). The isinstance dispatch hides this so
-    :class:`SurVAEFlow` keeps a uniform call site without wrapping
+    `SurVAEFlow` keeps a uniform call site without wrapping
     bijections in adapters.
     """
     if isinstance(transform, AbstractBijection):
@@ -43,7 +43,7 @@ def _to_base(
 ) -> tuple[Array, Array]:
     """Apply one chain element in the data -> base direction (used by ``log_prob``).
 
-    Mirror of :func:`_to_data`: bijections use ``inverse_and_log_det``
+    Mirror of `_to_data`: bijections use ``inverse_and_log_det``
     (FlowJax's "log_prob" side), surjections use ``forward_and_log_det``
     (SurVAE's data -> latent side).
     """
@@ -55,20 +55,20 @@ def _to_base(
 class SurVAEFlow(eqx.Module):
     """Container that threads PRNG keys through a mixed bijection / surjection chain.
 
-    Composes any sequence of :class:`flowjax.bijections.AbstractBijection` and
-    :class:`AbstractSurjection` transforms. Forward direction is base -> data
+    Composes any sequence of `flowjax.bijections.AbstractBijection` and
+    `AbstractSurjection` transforms. Forward direction is base -> data
     (used by ``sample``); inverse direction is data -> base (used by
     ``log_prob``). Each transform receives its own independent split of the
     user-supplied key, regardless of whether it actually consumes it — this
     keeps the call shape uniform and JIT-friendly.
 
-    For a chain consisting solely of :class:`AbstractBijection` instances,
+    For a chain consisting solely of `AbstractBijection` instances,
     ``log_prob`` is identical (up to numerical noise) to that of the
     equivalent ``flowjax.distributions.Transformed(base, Chain(transforms))``,
     so users can migrate without changing semantics.
 
     Attributes:
-        base_dist: A :class:`flowjax.distributions.AbstractDistribution`
+        base_dist: A `flowjax.distributions.AbstractDistribution`
             whose event shape matches the start of the forward chain.
         transforms: Tuple of bijections / surjections, applied left-to-right
             in the forward direction.
@@ -76,8 +76,8 @@ class SurVAEFlow(eqx.Module):
             input to ``log_prob``). Defaults to ``base_dist.shape`` for
             shape-preserving chains; **must** be supplied explicitly when
             the chain contains a surjection that changes dimensionality
-            (e.g. :class:`Slice`, :class:`Augment`,
-            :class:`SimpleMaxPoolSurjection2d`).
+            (e.g. `Slice`, `Augment`,
+            `SimpleMaxPoolSurjection2d`).
 
     Properties:
         lower_bound: ``True`` iff at least one surjection in the chain
@@ -93,13 +93,13 @@ class SurVAEFlow(eqx.Module):
         drive any subset of {base, couplings, FiLM-wrapped layers} —
         including:
 
-        - **base only**: pair a :class:`ConditionalDiagGaussian` /
-          :class:`ClassCondDiagGaussian` / :class:`NumpyroBase` (factory
+        - **base only**: pair a `ConditionalDiagGaussian` /
+          `ClassCondDiagGaussian` / `NumpyroBase` (factory
           mode) base with otherwise unconditional transforms.
         - **transforms only**: pair an unconditional base
-          (:class:`flowjax.distributions.Normal`, …) with one or more
+          (`flowjax.distributions.Normal`, …) with one or more
           coupling layers built with ``cond_dim > 0`` (or any transform
-          wrapped in :class:`Conditioner`).
+          wrapped in `Conditioner`).
         - **both**: a conditional base **and** condition-aware transforms;
           the same ``condition`` reaches both.
 
@@ -117,7 +117,7 @@ class SurVAEFlow(eqx.Module):
         - ``log_prob(x, key, condition)``: ``x`` of shape
           ``sample_shape + data_shape`` → ``sample_shape``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from flowjax.distributions import Normal
@@ -184,7 +184,7 @@ class SurVAEFlow(eqx.Module):
         """Sample by drawing from ``base_dist`` and pushing through to data.
 
         Each draw uses an independent key derived from ``key``; ``sample_shape``
-        is realised via :func:`jax.vmap` over a leading batch of keys, mirroring
+        is realised via `jax.vmap` over a leading batch of keys, mirroring
         the FlowJax convention.
         """
         cond = None if condition is None else jnp.asarray(condition)

--- a/src/gauss_flows/_src/inference/__init__.py
+++ b/src/gauss_flows/_src/inference/__init__.py
@@ -1,8 +1,8 @@
 """Inference utilities: NumPyro interop + training loops.
 
-- :mod:`.numpyro_compat` adapts a flowjax ``Transformed`` as a NumPyro distribution.
-- :mod:`.numpyro_guide` plugs that adapter into an ``AutoContinuous`` SVI guide.
-- :mod:`.train` wraps ``flowjax.train.fit_to_data`` with Gaussianization defaults.
+- `.numpyro_compat` adapts a flowjax ``Transformed`` as a NumPyro distribution.
+- `.numpyro_guide` plugs that adapter into an ``AutoContinuous`` SVI guide.
+- `.train` wraps ``flowjax.train.fit_to_data`` with Gaussianization defaults.
 """
 
 from gauss_flows._src.inference.numpyro_compat import FlowDist

--- a/src/gauss_flows/_src/inference/numpyro_compat.py
+++ b/src/gauss_flows/_src/inference/numpyro_compat.py
@@ -16,7 +16,7 @@ from jaxtyping import PRNGKeyArray
 class FlowDist(dist_lib.Distribution):
     """Wrap a flowjax ``Transformed`` distribution as a NumPyro distribution.
 
-    Subclasses :class:`numpyro.distributions.Distribution`, delegating
+    Subclasses `numpyro.distributions.Distribution`, delegating
     ``sample`` and ``log_prob`` to the wrapped flow. This lets
     Gaussianization flows (and other flowjax distributions) be used
     directly in NumPyro probabilistic programs with standard MCMC or
@@ -27,7 +27,7 @@ class FlowDist(dist_lib.Distribution):
     Args:
         flow: A flowjax ``Transformed`` distribution.
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import gaussianization_flow, FlowDist
         >>> flow = gaussianization_flow(jr.key(0), n_dims=2)

--- a/src/gauss_flows/_src/inference/numpyro_guide.py
+++ b/src/gauss_flows/_src/inference/numpyro_guide.py
@@ -1,6 +1,6 @@
 """NumPyro guide using Gaussianization flows for SVI.
 
-Provides :class:`FlowGuide`, a variational guide that uses a normalizing flow
+Provides `FlowGuide`, a variational guide that uses a normalizing flow
 as the approximate posterior for Stochastic Variational Inference (SVI).
 """
 
@@ -23,7 +23,7 @@ from gauss_flows._src.inference.numpyro_compat import FlowDist
 class FlowGuide(AutoContinuous):
     """NumPyro variational guide using a Gaussianization flow.
 
-    Subclasses :class:`numpyro.infer.autoguide.AutoContinuous`, using a
+    Subclasses `numpyro.infer.autoguide.AutoContinuous`, using a
     normalizing flow as the variational distribution for SVI. The flow
     models a joint distribution over the concatenated unconstrained latent
     space of the model, so it captures cross-variable correlations because
@@ -36,7 +36,7 @@ class FlowGuide(AutoContinuous):
         flow_factory: Callable that constructs a flowjax ``Transformed``
             distribution. Must accept ``key`` and ``n_dims`` positional /
             keyword arguments, plus any ``flow_kwargs``. Defaults to
-            :func:`~gauss_flows.gaussianization_flow`.
+            `gauss_flows.gaussianization_flow`.
         flow_kwargs: Extra keyword arguments forwarded to ``flow_factory``
             (e.g. ``n_layers``, ``n_components``). Defaults to ``{}``.
         init_key: JAX random key used to initialise the flow parameters.
@@ -46,10 +46,10 @@ class FlowGuide(AutoContinuous):
         prefix: Prefix used for numpyro parameter names. Defaults to
             ``"auto"``.
         init_loc_fn: Per-site initialization strategy. Defaults to
-            :func:`~numpyro.infer.initialization.init_to_uniform`.
+            `numpyro.infer.initialization.init_to_uniform`.
 
-    Example::
-
+    Examples:
+        ```python
         import jax.numpy as jnp
         import jax.random as jr
         import numpyro
@@ -65,6 +65,7 @@ class FlowGuide(AutoContinuous):
         guide = FlowGuide(model)
         svi = SVI(model, guide, Adam(1e-3), loss=Trace_ELBO())
         result = svi.run(jr.key(0), num_steps=100, obs=jnp.array([1.0]))
+        ```
     """
 
     def __init__(

--- a/src/gauss_flows/_src/inference/train.py
+++ b/src/gauss_flows/_src/inference/train.py
@@ -21,7 +21,7 @@ def fit_gaussianization_flow(
 ) -> tuple[AbstractDistribution, dict[str, list[float]]]:
     """Fit a Gaussianization flow to data by maximum likelihood.
 
-    Thin wrapper around :func:`flowjax.train.fit_to_data` with sensible
+    Thin wrapper around `flowjax.train.fit_to_data` with sensible
     defaults for Gaussianization flows. Minimises the negative
     log-likelihood with Adam and early stopping on a held-out validation
     split, returning the best-performing parameters.
@@ -29,7 +29,7 @@ def fit_gaussianization_flow(
     Args:
         key: JAX random key.
         dist: A flowjax distribution (e.g. from
-            :func:`~gauss_flows.gaussianization_flow`).
+            `gauss_flows.gaussianization_flow`).
         data: Training data array of shape ``(n_samples, n_dims)``.
         learning_rate: Adam optimizer learning rate. Defaults to 5e-4.
         max_epochs: Maximum training epochs. Defaults to 100.
@@ -43,17 +43,17 @@ def fit_gaussianization_flow(
         fitted flow and ``losses`` is a dict with ``"train"`` and ``"val"``
         lists of per-epoch losses.
 
-    Example:
-        .. code-block:: python
+    Examples:
+        ```python
+        import jax.random as jr
+        from gauss_flows import gaussianization_flow, fit_gaussianization_flow
 
-            import jax.random as jr
-            from gauss_flows import gaussianization_flow, fit_gaussianization_flow
-
-            data = jr.normal(jr.key(0), (1024, 2))
-            flow = gaussianization_flow(jr.key(1), n_dims=2, n_layers=2)
-            trained, losses = fit_gaussianization_flow(
-                jr.key(2), flow, data, max_epochs=5, show_progress=False
-            )
+        data = jr.normal(jr.key(0), (1024, 2))
+        flow = gaussianization_flow(jr.key(1), n_dims=2, n_layers=2)
+        trained, losses = fit_gaussianization_flow(
+            jr.key(2), flow, data, max_epochs=5, show_progress=False
+        )
+        ```
     """
     return fit_to_data(
         key,

--- a/src/gauss_flows/_src/info_theory.py
+++ b/src/gauss_flows/_src/info_theory.py
@@ -7,18 +7,18 @@ returned in **nats** (natural logarithm).
 
 * **Flow-based Monte-Carlo** estimators draw ``n_samples`` from a *trained*
   flow and average its exact change-of-variables log-density. They require a
-  ``key`` and converge as O(1/√N) (:func:`entropy`, :func:`total_correlation`,
-  :func:`mutual_information`, :func:`kl_divergence`, :func:`negentropy`).
+  ``key`` and converge as O(1/√N) (`entropy`, `total_correlation`,
+  `mutual_information`, `kl_divergence`, `negentropy`).
 * **Analytical Gaussian** closed forms evaluate the exact expression for a
   multivariate Gaussian from its covariance (and mean). They are deterministic
-  and take no samples (:func:`gaussian_entropy`,
-  :func:`gaussian_total_correlation`, :func:`gaussian_mutual_information`,
-  :func:`gaussian_kl_divergence`).
+  and take no samples (`gaussian_entropy`,
+  `gaussian_total_correlation`, `gaussian_mutual_information`,
+  `gaussian_kl_divergence`).
 * **RBIG-way reductions** accumulate the total correlation removed by a
   Gaussianization flow, pairing histogram marginal entropies with a Gaussian
-  joint entropy (:func:`information_reduction`,
-  :func:`total_correlation_reduction`, :func:`entropy_reduction`,
-  :func:`kl_divergence_reduction`).
+  joint entropy (`information_reduction`,
+  `total_correlation_reduction`, `entropy_reduction`,
+  `kl_divergence_reduction`).
 """
 
 from __future__ import annotations
@@ -35,9 +35,10 @@ def entropy(
 ) -> Array:
     """Differential entropy of a flow (flow-based Monte-Carlo estimator).
 
-    Draws samples from the trained ``dist`` and averages its exact log-density::
-
-        H(X) = −E[log p(X)] ≈ −(1/N) Σᵢ log p(xᵢ),   xᵢ ∼ dist.
+    Draws samples from the trained ``dist`` and averages its exact log-density:
+    ```python
+    H(X) = −E[log p(X)] ≈ −(1/N) Σᵢ log p(xᵢ),   xᵢ ∼ dist.
+    ```
 
     The estimate converges as O(1/√N) in ``n_samples``.
 
@@ -50,13 +51,14 @@ def entropy(
     Returns:
         Scalar differential-entropy estimate (in nats).
 
-    Example:
-        Requires a fitted flow, so the call is slow and non-deterministic::
+    Examples:
+        Requires a fitted flow, so the call is slow and non-deterministic:
+        ```python
+        import jax.random as jr
+        from gauss_flows import entropy
 
-            import jax.random as jr
-            from gauss_flows import entropy
-
-            h = entropy(trained_flow, n_samples=10000, key=jr.key(0))
+        h = entropy(trained_flow, n_samples=10000, key=jr.key(0))
+        ```
     """
     samples = dist.sample(key, (n_samples,))
     log_probs = dist.log_prob(samples)
@@ -69,9 +71,10 @@ def total_correlation(
     """Total correlation of a flow (flow-based Monte-Carlo estimator).
 
     Total correlation (multi-information) is the gap between the sum of marginal
-    entropies and the joint entropy::
-
-        TC(X) = Σᵢ H(Xᵢ) − H(X).
+    entropies and the joint entropy:
+    ```python
+    TC(X) = Σᵢ H(Xᵢ) − H(X).
+    ```
 
     Samples are drawn from the trained ``dist``; the joint entropy is the
     Monte-Carlo average −(1/N) Σ log p(xᵢ), while each marginal entropy uses a
@@ -85,13 +88,14 @@ def total_correlation(
     Returns:
         Scalar total-correlation estimate (in nats).
 
-    Example:
-        Requires a fitted flow, so the call is slow and non-deterministic::
+    Examples:
+        Requires a fitted flow, so the call is slow and non-deterministic:
+        ```python
+        import jax.random as jr
+        from gauss_flows import total_correlation
 
-            import jax.random as jr
-            from gauss_flows import total_correlation
-
-            tc = total_correlation(trained_flow, n_samples=10000, key=jr.key(0))
+        tc = total_correlation(trained_flow, n_samples=10000, key=jr.key(0))
+        ```
     """
     import jax.random as jr
 
@@ -127,11 +131,12 @@ def mutual_information(
     """Mutual information I(X; Y) of flows (flow-based Monte-Carlo estimator).
 
     Combines three Monte-Carlo entropy estimates of the supplied trained
-    flows::
+    flows:
+    ```python
+    I(X; Y) = H(X) + H(Y) − H(X, Y).
+    ```
 
-        I(X; Y) = H(X) + H(Y) − H(X, Y).
-
-    Each entropy is estimated via :func:`entropy` from independent sample
+    Each entropy is estimated via `entropy` from independent sample
     batches, so the result converges as O(1/√N).
 
     Args:
@@ -145,13 +150,14 @@ def mutual_information(
     Returns:
         Scalar mutual-information estimate (in nats).
 
-    Example:
-        Requires fitted flows, so the call is slow and non-deterministic::
+    Examples:
+        Requires fitted flows, so the call is slow and non-deterministic:
+        ```python
+        import jax.random as jr
+        from gauss_flows import mutual_information
 
-            import jax.random as jr
-            from gauss_flows import mutual_information
-
-            mi = mutual_information(flow_xy, flow_x, flow_y, key=jr.key(0))
+        mi = mutual_information(flow_xy, flow_x, flow_y, key=jr.key(0))
+        ```
     """
     import jax.random as jr
 
@@ -172,10 +178,11 @@ def kl_divergence(
     """KL divergence KL(P ‖ Q) of flows (flow-based Monte-Carlo estimator).
 
     Samples are drawn from ``dist_p`` and both flows' exact log-densities are
-    averaged::
-
-        KL(P ‖ Q) = E_P[log p(X) − log q(X)]
-                  ≈ (1/N) Σᵢ [log p(xᵢ) − log q(xᵢ)],   xᵢ ∼ dist_p.
+    averaged:
+    ```python
+    KL(P ‖ Q) = E_P[log p(X) − log q(X)]
+              ≈ (1/N) Σᵢ [log p(xᵢ) − log q(xᵢ)],   xᵢ ∼ dist_p.
+    ```
 
     Converges as O(1/√N) in ``n_samples``.
 
@@ -188,13 +195,14 @@ def kl_divergence(
     Returns:
         Scalar KL-divergence estimate (in nats).
 
-    Example:
-        Requires fitted flows, so the call is slow and non-deterministic::
+    Examples:
+        Requires fitted flows, so the call is slow and non-deterministic:
+        ```python
+        import jax.random as jr
+        from gauss_flows import kl_divergence
 
-            import jax.random as jr
-            from gauss_flows import kl_divergence
-
-            kl = kl_divergence(flow_p, flow_q, n_samples=10000, key=jr.key(0))
+        kl = kl_divergence(flow_p, flow_q, n_samples=10000, key=jr.key(0))
+        ```
     """
     samples = dist_p.sample(key, (n_samples,))
     log_p = dist_p.log_prob(samples)
@@ -208,13 +216,14 @@ def negentropy(
     """Negentropy of a flow (flow-based Monte-Carlo estimator).
 
     Negentropy is the entropy gap to the Gaussian of matched moments — a
-    non-negative measure of non-Gaussianity::
-
-        J(X) = H(X_gauss) − H(X),
+    non-negative measure of non-Gaussianity:
+    ```python
+    J(X) = H(X_gauss) − H(X),
+    ```
 
     where ``X_gauss`` is the Normal sharing the per-dimension mean and standard
     deviation of the samples drawn from ``dist``. Both entropies are estimated
-    via :func:`entropy`, so the result converges as O(1/√N).
+    via `entropy`, so the result converges as O(1/√N).
 
     Args:
         dist: A trained flowjax distribution.
@@ -224,13 +233,14 @@ def negentropy(
     Returns:
         Scalar negentropy estimate (in nats).
 
-    Example:
-        Requires a fitted flow, so the call is slow and non-deterministic::
+    Examples:
+        Requires a fitted flow, so the call is slow and non-deterministic:
+        ```python
+        import jax.random as jr
+        from gauss_flows import negentropy
 
-            import jax.random as jr
-            from gauss_flows import negentropy
-
-            j = negentropy(trained_flow, n_samples=10000, key=jr.key(0))
+        j = negentropy(trained_flow, n_samples=10000, key=jr.key(0))
+        ```
     """
     import jax.random as jr
     from flowjax.distributions import Normal
@@ -258,9 +268,10 @@ def negentropy(
 def gaussian_entropy(covariance: ArrayLike) -> Array:
     """Differential entropy of a Gaussian (analytical Gaussian closed form).
 
-    Deterministic, sample-free closed form in the covariance::
-
-        H(X) = ½ log |2π e Σ| = ½ (d log(2π e) + log|Σ|).
+    Deterministic, sample-free closed form in the covariance:
+    ```python
+    H(X) = ½ log |2π e Σ| = ½ (d log(2π e) + log|Σ|).
+    ```
 
     Args:
         covariance: Covariance matrix Σ of shape ``(d, d)``.
@@ -268,7 +279,7 @@ def gaussian_entropy(covariance: ArrayLike) -> Array:
     Returns:
         Scalar differential entropy (in nats).
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import gaussian_entropy
         >>> round(float(gaussian_entropy(jnp.eye(3))), 4)
@@ -284,9 +295,10 @@ def gaussian_total_correlation(covariance: ArrayLike) -> Array:
     """Total correlation of a Gaussian (analytical Gaussian closed form).
 
     Deterministic, sample-free closed form comparing the diagonal variances to
-    the full covariance::
-
-        TC(X) = ½ [ Σᵢ log Σᵢᵢ − log|Σ| ].
+    the full covariance:
+    ```python
+    TC(X) = ½ [ Σᵢ log Σᵢᵢ − log|Σ| ].
+    ```
 
     It is zero exactly when Σ is diagonal (independent components).
 
@@ -296,7 +308,7 @@ def gaussian_total_correlation(covariance: ArrayLike) -> Array:
     Returns:
         Scalar total correlation (in nats).
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import gaussian_total_correlation
         >>> cov = jnp.array([[1.0, 0.5], [0.5, 1.0]])
@@ -315,11 +327,12 @@ def gaussian_mutual_information(covariance: ArrayLike, dim_x: int) -> Array:
     """Mutual information of Gaussian blocks (analytical Gaussian closed form).
 
     Deterministic, sample-free closed form. The joint covariance is partitioned
-    into the leading ``dim_x`` dimensions (X) and the remainder (Y), then::
+    into the leading ``dim_x`` dimensions (X) and the remainder (Y), then:
+    ```python
+    I(X; Y) = H(X) + H(Y) − H(X, Y),
+    ```
 
-        I(X; Y) = H(X) + H(Y) − H(X, Y),
-
-    each entropy evaluated via :func:`gaussian_entropy`.
+    each entropy evaluated via `gaussian_entropy`.
 
     Args:
         covariance: Joint covariance matrix of ``[X, Y]`` of shape ``(d, d)``.
@@ -328,7 +341,7 @@ def gaussian_mutual_information(covariance: ArrayLike, dim_x: int) -> Array:
     Returns:
         Scalar mutual information (in nats).
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import gaussian_mutual_information
         >>> cov = jnp.array([[1.0, 0.5], [0.5, 1.0]])
@@ -349,11 +362,12 @@ def gaussian_kl_divergence(
 ) -> Array:
     """KL divergence of two Gaussians (analytical Gaussian closed form).
 
-    Deterministic, sample-free closed form::
-
-        KL(N_p ‖ N_q) = ½ [ tr(Σ_q⁻¹ Σ_p)
-                            + (μ_q − μ_p)ᵀ Σ_q⁻¹ (μ_q − μ_p) − d
-                            + log(|Σ_q| / |Σ_p|) ].
+    Deterministic, sample-free closed form:
+    ```python
+    KL(N_p ‖ N_q) = ½ [ tr(Σ_q⁻¹ Σ_p)
+                        + (μ_q − μ_p)ᵀ Σ_q⁻¹ (μ_q − μ_p) − d
+                        + log(|Σ_q| / |Σ_p|) ].
+    ```
 
     It is zero exactly when the two Gaussians coincide.
 
@@ -366,7 +380,7 @@ def gaussian_kl_divergence(
     Returns:
         Scalar KL divergence (in nats).
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import gaussian_kl_divergence
         >>> mu, eye = jnp.zeros(2), jnp.eye(2)
@@ -471,9 +485,10 @@ def information_reduction(
     """Total correlation removed between two representations (RBIG-way reduction).
 
     The building block of the RBIG-way estimators: the drop in total
-    correlation when moving from ``x_before`` to ``x_after``::
-
-        Δ_TC = TC(x_before) − TC(x_after),
+    correlation when moving from ``x_before`` to ``x_after``:
+    ```python
+    Δ_TC = TC(x_before) − TC(x_after),
+    ```
 
     with ``TC(X) = Σᵢ H(Xᵢ) − H(X)``, marginal entropies estimated from
     histograms and the joint entropy from the Gaussian (maximum-entropy)
@@ -487,12 +502,13 @@ def information_reduction(
     Returns:
         Scalar total-correlation reduction (in nats).
 
-    Example:
-        Plain sampled data, no flow required::
+    Examples:
+        Plain sampled data, no flow required:
+        ```python
+        from gauss_flows import information_reduction
 
-            from gauss_flows import information_reduction
-
-            delta_tc = information_reduction(x_before, x_after)
+        delta_tc = information_reduction(x_before, x_after)
+        ```
     """
     xb = jnp.asarray(x_before)
     xa = jnp.asarray(x_after)
@@ -507,9 +523,10 @@ def total_correlation_reduction(
 
     The flow Gaussianizes the data, ``z = f(x)``, via ``flow.bijection.inverse``.
     The total correlation removed is the drop from the data to the
-    (approximately independent) latent representation::
-
-        TC(X) ~= TC(x) - TC(z)
+    (approximately independent) latent representation:
+    ```python
+    TC(X) ~= TC(x) - TC(z)
+    ```
 
     which mirrors RBIG's ``total_correlation_reduction``. No Jacobian is needed.
 
@@ -534,7 +551,7 @@ def entropy_reduction(
 
     Uses the decomposition ``H(X) = sum_i H(X_i) - TC(X)`` with the marginal
     entropies estimated from histograms and ``TC(X)`` obtained from
-    :func:`total_correlation_reduction`.
+    `total_correlation_reduction`.
 
     Args:
         flow: A fitted flowjax ``Transformed`` distribution.
@@ -578,9 +595,10 @@ def kl_divergence_reduction(
     fitted to). Applying that same map to samples ``x_query`` drawn from ``P``
     gives ``z = f_Q(x)``; if ``P == Q`` then ``z`` is standard normal. The
     divergence is recovered as the per-marginal KL to a standard normal plus the
-    residual total correlation::
-
-        KL(P || Q) ~= sum_d KL(z_d || N(0, 1)) + TC(z)
+    residual total correlation:
+    ```python
+    KL(P || Q) ~= sum_d KL(z_d || N(0, 1)) + TC(z)
+    ```
 
     This mirrors RBIG's ``estimate_kld`` and requires no Jacobian.
 

--- a/src/gauss_flows/_src/init/rbig.py
+++ b/src/gauss_flows/_src/init/rbig.py
@@ -2,17 +2,17 @@
 
 These functions return a fully-configured flow by greedily fitting each
 block to the data (non-gradient), then wrapping the stack into a
-:class:`flowjax.distributions.Transformed`. The result is already a
+`flowjax.distributions.Transformed`. The result is already a
 reasonable density estimator before any gradient training, and can be
 refined further by the usual NLL minimisation.
 
 Two variants:
 
-- :func:`fit_rbig` — the canonical diagonal flow: alternating PCA rotation
+- `fit_rbig` — the canonical diagonal flow: alternating PCA rotation
   and per-dim mixture-of-Gaussians CDF Gaussianization. Mirrors the
   Laparra & Malo (2011) RBIG algorithm.
-- :func:`fit_rbig_coupling` — warm-start for a coupling-based flow:
-  each block is rotation + :class:`MixtureGaussianCDFCoupling` where the
+- `fit_rbig_coupling` — warm-start for a coupling-based flow:
+  each block is rotation + `MixtureGaussianCDFCoupling` where the
   conditioner is initialised so the layer acts like a diagonal mixture
   Gaussianization on the transformed half. Training then lets the
   conditioner learn to modulate on the untransformed half.
@@ -69,10 +69,10 @@ def _fit_marginal(
     block_idx: int,
     random_state: int,
 ) -> MixtureGaussianCDF:
-    """Build a :class:`MixtureGaussianCDF` with per-dim GMM-fitted params.
+    """Build a `MixtureGaussianCDF` with per-dim GMM-fitted params.
 
     Translates sklearn's ``(weights, means, scales)`` into the
-    :class:`MixtureGaussianCDF` convention, where the stored
+    `MixtureGaussianCDF` convention, where the stored
     ``log_weights``, ``means``, ``log_scales`` are used as
     ``softmax(log_weights)`` and ``softplus(log_scales) + 5e-3`` at
     forward time.
@@ -125,10 +125,10 @@ def fit_rbig(
     the current data state — a per-dimension sklearn ``GaussianMixture``
     EM fit, no gradient training — and propagating the data forward
     before the next block. The result is a warm start: a
-    :class:`flowjax.distributions.Transformed` whose ``log_prob`` is
+    `flowjax.distributions.Transformed` whose ``log_prob`` is
     already a reasonable density estimator and can be refined further by
     the usual NLL minimisation (see
-    :func:`~gauss_flows.fit_gaussianization_flow`).
+    `gauss_flows.fit_gaussianization_flow`).
 
     Args:
         x: Training data of shape ``(n, d)``.
@@ -145,7 +145,7 @@ def fit_rbig(
     Raises:
         ValueError: If ``x`` is not 2-D.
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import fit_rbig
         >>> x = jr.normal(jr.key(0), (500, 2))
@@ -181,7 +181,7 @@ def _pack_coupling_bias(
 ) -> np.ndarray:
     """Flatten per-b-dim mixture params into the conditioner's bias vector.
 
-    :class:`flowjax.bijections.Coupling` reshapes the conditioner output
+    `flowjax.bijections.Coupling` reshapes the conditioner output
     as ``(d_b, params_per_dim)`` and feeds each row through
     ``transformer_constructor``. The ravelled transformer has three
     inexact-array fields in declaration order: ``logits``, ``means``,
@@ -218,8 +218,8 @@ def _push_forward_b_half_diag(
 ) -> np.ndarray:
     """Advance state via the ``MixtureGaussianCDF`` forward on ``y[:, b_idx]``.
 
-    Used by :func:`fit_rbig_coupling` to propagate state between blocks
-    along the *same* numerical path as :func:`fit_rbig`, so the two warm
+    Used by `fit_rbig_coupling` to propagate state between blocks
+    along the *same* numerical path as `fit_rbig`, so the two warm
     starts see identical ``y`` states at every block and their GMM fits
     agree exactly. Without this, each coupling's slightly different
     numerical forward (different log-pdf formula, different scale
@@ -358,11 +358,11 @@ def fit_rbig_coupling(
     Each block is ``[FixedRotation (PCA), MixtureGaussianCDFCoupling]``.
     The coupling's conditioner is initialised in closed form — no gradient
     training — with a zero kernel and a bias set from per-b-dim sklearn
-    ``GaussianMixture`` fits (via :func:`_init_coupling_from_fits`), so
+    ``GaussianMixture`` fits (via `_init_coupling_from_fits`), so
     the layer starts as a constant-in-``x_a`` mixture-CDF transform on the
     ``x_b`` half — numerically equivalent to a diagonal marginal fit on
     the ``x_b`` dims. Gradient training (see
-    :func:`~gauss_flows.fit_gaussianization_flow`) can then break the
+    `gauss_flows.fit_gaussianization_flow`) can then break the
     constancy and let the conditioner modulate on ``x_a``.
 
     Args:
@@ -383,7 +383,7 @@ def fit_rbig_coupling(
         ValueError: If ``x`` is not 2-D, or ``d`` is less than 2 or odd
             (the half-swap coupling pair requires an even number of dims).
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import fit_rbig_coupling
         >>> x = jr.normal(jr.key(0), (500, 2))

--- a/src/gauss_flows/_src/nn/diffeq_nets.py
+++ b/src/gauss_flows/_src/nn/diffeq_nets.py
@@ -112,7 +112,7 @@ class DiffeqMLP(eqx.Module):
           ``control_dim == 0``
         - Output: ``(dim,)``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import DiffeqMLP, pack_time_control
@@ -178,7 +178,7 @@ class DiffeqConcat(eqx.Module):
 
     This variant replaces the raw ODE time with ``time_net(ode_time)`` before
     concatenation, while preserving the same packed-condition API as
-    :class:`DiffeqMLP`.
+    `DiffeqMLP`.
 
     Args:
         key: PRNG key for the MLP and default time net.
@@ -186,7 +186,7 @@ class DiffeqConcat(eqx.Module):
         control_dim: Size of the optional control vector ``c``.
         hidden: Hidden-layer widths.
         time_net: Optional scalar time embedding. When omitted, a
-            :class:`gauss_flows.TimeFourier` module is created.
+            `gauss_flows.TimeFourier` module is created.
         activation: Non-linearity applied after each hidden layer.
 
     Shape:
@@ -196,7 +196,7 @@ class DiffeqConcat(eqx.Module):
           ``control_dim == 0``
         - Output: ``(dim,)``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import DiffeqConcat, pack_time_control

--- a/src/gauss_flows/_src/nn/time_net.py
+++ b/src/gauss_flows/_src/nn/time_net.py
@@ -38,7 +38,7 @@ class TimeFourier(eqx.Module):
         - Input ``t``: ``()`` or ``(1,)``
         - Output: scalar ``()``
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import TimeFourier
         >>> gate = TimeFourier(jr.key(0), embedding_dim=8)
@@ -78,7 +78,7 @@ class TimeTanh(eqx.Module):
         - Input ``t``: ``()`` or ``(1,)``
         - Output: scalar ``()``
 
-    Example:
+    Examples:
         >>> import jax.random as jr
         >>> from gauss_flows import TimeTanh
         >>> gate = TimeTanh(jr.key(0), embedding_dim=8)
@@ -108,7 +108,7 @@ class TimeIdentity(eqx.Module):
         - Input ``t``: ``()`` or ``(1,)``
         - Output: scalar ``()``
 
-    Example:
+    Examples:
         >>> from gauss_flows import TimeIdentity
         >>> gate = TimeIdentity()
         >>> float(gate(0.25))

--- a/src/gauss_flows/_src/transforms/__init__.py
+++ b/src/gauss_flows/_src/transforms/__init__.py
@@ -1,7 +1,7 @@
 """Transforms sub-package for gauss_flows.
 
 Re-exports every transform class from the nested SurVAE-taxonomy
-subpackages (:mod:`.bijections`, :mod:`.surjections`, :mod:`.stochastic`)
+subpackages (`.bijections`, `.surjections`, `.stochastic`)
 so downstream code can keep importing from ``gauss_flows._src.transforms``
 without caring which leaf module a class lives in.
 """

--- a/src/gauss_flows/_src/transforms/_sphere_utils.py
+++ b/src/gauss_flows/_src/transforms/_sphere_utils.py
@@ -34,7 +34,7 @@ def tangent_basis(x: Array) -> Array:
         Input: ``(d+1,)``.
         Output: ``(d+1, d)`` with ``Eᵀ E = I`` and ``xᵀ E = 0``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import tangent_basis
         >>> x = jnp.array([0.0, 0.0, 1.0])
@@ -76,7 +76,7 @@ def expmap_sphere(
         ``x`` and ``v`` are single events of shape ``(d+1,)``.
         Returns a single point on the sphere with shape ``(d+1,)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import expmap_sphere
         >>> x = jnp.array([0.0, 0.0, 1.0])
@@ -99,10 +99,10 @@ def logmap_sphere(
 ) -> Array:
     """Return the tangent vector at ``x`` whose exp-map reaches ``y``.
 
-    Inverse of :func:`expmap_sphere`: ``expmap(x, logmap(x, y)) ≈ y``. The
+    Inverse of `expmap_sphere`: ``expmap(x, logmap(x, y)) ≈ y``. The
     log map is not uniquely defined when ``y`` is antipodal to ``x``; this
     implementation returns ``π · e`` for a deterministic tangent direction
-    ``e`` obtained from :func:`tangent_basis`, which at least satisfies
+    ``e`` obtained from `tangent_basis`, which at least satisfies
     ``‖logmap‖ == π`` (the geodesic distance to the antipode) and is
     continuous under perturbations of ``x``.
 
@@ -118,7 +118,7 @@ def logmap_sphere(
         ``x`` and ``y`` are single points on the sphere with shape ``(d+1,)``.
         Returns a tangent vector in ``Tₓ Sᵈ`` with shape ``(d+1,)``.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import expmap_sphere, logmap_sphere
         >>> x = jnp.array([0.0, 0.0, 1.0])

--- a/src/gauss_flows/_src/transforms/base.py
+++ b/src/gauss_flows/_src/transforms/base.py
@@ -39,7 +39,7 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 class AbstractSurjection(eqx.Module):
     """Base class for SurVAE surjective transforms.
 
-    Subclasses set the three class-level flags so :class:`SurVAEFlow` (and
+    Subclasses set the three class-level flags so `SurVAEFlow` (and
     other containers) can decide whether ``log_prob`` is exact or only an
     evidence lower bound:
 

--- a/src/gauss_flows/_src/transforms/bijections/__init__.py
+++ b/src/gauss_flows/_src/transforms/bijections/__init__.py
@@ -3,14 +3,14 @@
 Subpackages group bijections by technique so the hierarchy mirrors the
 SurVAE taxonomy:
 
-- :mod:`.coupling` — masked-conditioner couplings.
-- :mod:`.continuous` — ODE-defined continuous normalizing flows.
-- :mod:`.elementwise` — pointwise CDF / spline layers that act on each dim.
-- :mod:`.linear` — matrix-shaped layers: rotations, LU, 1×1 conv, conv-exp.
-- :mod:`.normalization` — ActNorm + invertible BatchNorm.
-- :mod:`.reshape` — volume-preserving shape rewriters (Squeeze).
-- :mod:`.periodic` — wrap / shift primitives on the torus.
-- :mod:`.classic` — low-expressivity VI-only flows (Planar, Sylvester).
+- `.coupling` — masked-conditioner couplings.
+- `.continuous` — ODE-defined continuous normalizing flows.
+- `.elementwise` — pointwise CDF / spline layers that act on each dim.
+- `.linear` — matrix-shaped layers: rotations, LU, 1×1 conv, conv-exp.
+- `.normalization` — ActNorm + invertible BatchNorm.
+- `.reshape` — volume-preserving shape rewriters (Squeeze).
+- `.periodic` — wrap / shift primitives on the torus.
+- `.classic` — low-expressivity VI-only flows (Planar, Sylvester).
 """
 
 from __future__ import annotations

--- a/src/gauss_flows/_src/transforms/bijections/classic/__init__.py
+++ b/src/gauss_flows/_src/transforms/bijections/classic/__init__.py
@@ -4,7 +4,7 @@ Both transforms predate coupling and spline flows. They are useful as
 teaching baselines and as variational-inference-only flows: they have no
 algebraic inverse, so they can be used to sample from ``base -> data`` but
 cannot evaluate ``log_prob`` on arbitrary points. Use
-:meth:`flowjax.distributions.Transformed.sample_and_log_prob` in the VI
+`flowjax.distributions.Transformed.sample_and_log_prob` in the VI
 setting.
 
 References:

--- a/src/gauss_flows/_src/transforms/bijections/classic/planar.py
+++ b/src/gauss_flows/_src/transforms/bijections/classic/planar.py
@@ -1,7 +1,7 @@
 """Planar normalizing flow (Rezende & Mohamed 2015).
 
 No algebraic inverse; use only in the generative / variational-inference
-direction via :meth:`flowjax.distributions.Transformed.sample_and_log_prob`.
+direction via `flowjax.distributions.Transformed.sample_and_log_prob`.
 """
 
 from typing import ClassVar
@@ -24,7 +24,7 @@ class PlanarFlow(AbstractBijection):
 
     The forward map has no closed-form inverse, so this layer is generative-only:
     use it in the sampling / variational-inference direction via
-    :meth:`flowjax.distributions.Transformed.sample_and_log_prob`.
+    `flowjax.distributions.Transformed.sample_and_log_prob`.
 
     Args:
         key: PRNG key used to initialise ``u`` and ``w``.
@@ -41,7 +41,7 @@ class PlanarFlow(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   not implemented (raises)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import PlanarFlow

--- a/src/gauss_flows/_src/transforms/bijections/classic/sylvester.py
+++ b/src/gauss_flows/_src/transforms/bijections/classic/sylvester.py
@@ -1,7 +1,7 @@
 """Sylvester normalizing flow (van den Berg et al. 2018).
 
 No algebraic inverse; use only in the generative / variational-inference
-direction via :meth:`flowjax.distributions.Transformed.sample_and_log_prob`.
+direction via `flowjax.distributions.Transformed.sample_and_log_prob`.
 """
 
 from typing import ClassVar
@@ -17,7 +17,7 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 class SylvesterFlow(AbstractBijection):
     """Sylvester normalizing flow (van den Berg et al. 2018).
 
-    Generalises :class:`PlanarFlow` from a rank-1 to a rank-``M`` (``M ≤ D``)
+    Generalises `PlanarFlow` from a rank-1 to a rank-``M`` (``M ≤ D``)
     perturbation:
 
         ``y = x + Q · R̃ · tanh(R · Qᵀ · x + b)``
@@ -31,7 +31,7 @@ class SylvesterFlow(AbstractBijection):
 
     The forward map has no closed-form inverse, so this layer is generative-only:
     use it in the sampling / variational-inference direction via
-    :meth:`flowjax.distributions.Transformed.sample_and_log_prob`.
+    `flowjax.distributions.Transformed.sample_and_log_prob`.
 
     Args:
         key: PRNG key used to initialise all parameters.
@@ -51,7 +51,7 @@ class SylvesterFlow(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   not implemented (raises)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import SylvesterFlow
@@ -135,8 +135,8 @@ class SylvesterFlow(AbstractBijection):
         """Materialise ``Q`` as a ``(D, M)`` matrix.
 
         Used by tests to verify orthonormality. The hot path
-        (``transform_and_log_det``) uses :meth:`_q_apply` /
-        :meth:`_q_transpose_apply` and never builds this matrix.
+        (``transform_and_log_det``) uses `_q_apply` /
+        `_q_transpose_apply` and never builds this matrix.
         """
         m = self.householder_vectors.shape[0]
         return jax.vmap(self._q_apply, in_axes=1, out_axes=1)(jnp.eye(m))

--- a/src/gauss_flows/_src/transforms/bijections/conditioner.py
+++ b/src/gauss_flows/_src/transforms/bijections/conditioner.py
@@ -17,28 +17,30 @@ class Conditioner(AbstractBijection):
 
     Computes
 
-    .. math:: y = \\exp(\\log\\sigma(c)) \\cdot f(x) + \\mu(c)
+    $$
+    y = \\exp(\\log\\sigma(c)) \\cdot f(x) + \\mu(c)
+    $$
 
     where ``f`` is the inner bijection and
     ``(\\mu, \\log\\sigma) = \\text{split}(g(c))`` are produced by a single
-    user-supplied (or default :class:`equinox.nn.MLP`) network with
+    user-supplied (or default `equinox.nn.MLP`) network with
     ``2 * D`` outputs — same coupling-net pattern used by
-    :class:`AffineCoupling` and :class:`ConditionalDiagGaussian`.
+    `AffineCoupling` and `ConditionalDiagGaussian`.
 
     Use this for transforms that genuinely cannot accept a condition
     (rotations, normalisations, fixed orthogonal layers, …). For coupling
     layers and other transforms that natively take a condition, pass
-    ``cond_dim`` directly rather than wrapping in :class:`Conditioner`.
+    ``cond_dim`` directly rather than wrapping in `Conditioner`.
 
     Args:
-        key: PRNG key used to initialise the default :class:`equinox.nn.MLP`.
+        key: PRNG key used to initialise the default `equinox.nn.MLP`.
             Ignored when a pre-built ``context_net`` is supplied.
         inner: Any bijection whose ``cond_shape`` is ``None``. Strict — wrap
             only genuinely unconditional inner transforms; raise otherwise.
         cond_shape: Context shape ``(cond_dim,)``. 1-D only.
         context_net: Optional pre-built callable
             ``(cond_dim,) -> (2 * D,)``. Default builds an
-            :class:`equinox.nn.MLP`.
+            `equinox.nn.MLP`.
         nn_width: Width of the default MLP.
         nn_depth: Depth of the default MLP.
         activation: Activation between hidden layers of the default MLP.
@@ -48,7 +50,7 @@ class Conditioner(AbstractBijection):
         - Condition: ``(cond_dim,)``
         - ``log_det``: scalar ``()``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import Conditioner, OrthogonalRotation

--- a/src/gauss_flows/_src/transforms/bijections/continuous/ffjord.py
+++ b/src/gauss_flows/_src/transforms/bijections/continuous/ffjord.py
@@ -45,7 +45,7 @@ class FFJORD(AbstractBijection):
     over a time span ``[t0, t1]`` using ``diffrax``. The trace term is computed
     either exactly with ``jax.jacfwd`` (cost ``O(dim)`` per ODE step — use for
     small ``dim`` or validation) or stochastically with Hutchinson's identity
-    via :mod:`matfree` (cost ``O(n_hutchinson_samples)`` per step).
+    via `matfree` (cost ``O(n_hutchinson_samples)`` per step).
 
     Hutchinson probes are **fixed per FFJORD instance**: the ``trace_key`` is
     stored once at construction and reused across every call to
@@ -53,14 +53,14 @@ class FFJORD(AbstractBijection):
     internal ODE step. This is the "fixed noise" FFJORD variant (Grathwohl
     et al. 2019, Appendix C) — it makes ``log_det`` a deterministic function
     of parameters and stabilises gradient optimisation. To draw new probes,
-    construct a new :class:`FFJORD` with a freshly split key.
+    construct a new `FFJORD` with a freshly split key.
 
     Args:
         key: PRNG key for the default vector field and Hutchinson probes.
         shape: Event shape ``(dim,)``.
         vector_field: Module with signature
             ``f(ode_time, x, condition) -> dx_dt``. When omitted, a default
-            :class:`gauss_flows.DiffeqMLP` is created.
+            `gauss_flows.DiffeqMLP` is created.
         control_dim: Size of the packed control vector ``c``.
         t_span: Integration interval ``(t0, t1)``.
         solver: ODE solver name.
@@ -77,10 +77,10 @@ class FFJORD(AbstractBijection):
             - ``control_dim == 0``: ``cond_shape = None`` — no condition
               accepted (unconditional FFJORD; diffrax supplies the ODE time).
             - ``control_dim > 0``: ``(1 + control_dim,)`` packed as
-              ``[t_query, c]`` via :func:`gauss_flows.pack_time_control`.
+              ``[t_query, c]`` via `gauss_flows.pack_time_control`.
         - Output ``log_det``: scalar ``()``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import DiffeqMLP, FFJORD, pack_time_control

--- a/src/gauss_flows/_src/transforms/bijections/coupling/affine.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/affine.py
@@ -19,8 +19,8 @@ class AffineCoupling(AbstractBijection):
     With ``cond_dim`` set, the same MLP additionally consumes an external
     context vector concatenated onto the first-half input.
 
-    Wraps :class:`flowjax.bijections.Coupling` with an
-    :class:`flowjax.bijections.affine.Affine` transformer; this class adds the
+    Wraps `flowjax.bijections.Coupling` with an
+    `flowjax.bijections.affine.Affine` transformer; this class adds the
     convention that an unconditional layer (``cond_dim=None``) drops any
     incoming ``condition`` so a base-only condition cannot leak into the inner
     MLP.
@@ -42,7 +42,7 @@ class AffineCoupling(AbstractBijection):
         - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
         (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import AffineCoupling

--- a/src/gauss_flows/_src/transforms/bijections/coupling/circular_spline.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/circular_spline.py
@@ -27,12 +27,12 @@ class CircularRQSplineCoupling(AbstractBijection):
     Implements the construction of Rezende et al. 2020 for densities on the
     n-torus. **All input dims are assumed periodic** with period ``2·bound``.
     For mixed periodic/linear inputs, compose this with a regular
-    :class:`RQSplineCoupling` via ``flowjax.bijections.Chain``.
+    `RQSplineCoupling` via ``flowjax.bijections.Chain``.
 
     Two ingredients combine to make the resulting log-density continuous across
     the wrap join:
 
-    1. The per-dim transformer is :class:`CircularRationalQuadraticSpline`
+    1. The per-dim transformer is `CircularRationalQuadraticSpline`
        (tied endpoint derivatives → C¹ across the join).
     2. The conditioner sees ``[sin(x_cond), cos(x_cond)]`` features rather than
        raw angles, so it cannot distinguish ``-π+ε`` from ``+π-ε``.
@@ -63,7 +63,7 @@ class CircularRQSplineCoupling(AbstractBijection):
         - transform_and_log_det: (n_dims,) → (n_dims,), scalar log_det
         - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import CircularRQSplineCoupling

--- a/src/gauss_flows/_src/transforms/bijections/coupling/continuous_affine_coupling.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/continuous_affine_coupling.py
@@ -42,12 +42,12 @@ class ContinuousAffineCoupling(AbstractBijection):
         n_layers: Depth of the conditioner MLP.
         time_net: Optional pre-built gate ``g`` with ``g(0) = 0``. Any
             ``equinox.Module`` with a scalar-in / scalar-out ``__call__`` works
-            — see :class:`gauss_flows.TimeFourier`, :class:`gauss_flows.TimeTanh`,
-            :class:`gauss_flows.TimeIdentity`. When ``None``, a
-            :class:`gauss_flows.TimeFourier` gate is built with
+            — see `gauss_flows.TimeFourier`, `gauss_flows.TimeTanh`,
+            `gauss_flows.TimeIdentity`. When ``None``, a
+            `gauss_flows.TimeFourier` gate is built with
             ``embedding_dim=time_embedding_dim``.
         time_embedding_dim: Number of Fourier features used by the default
-            :class:`gauss_flows.TimeFourier` gate. Ignored when ``time_net`` is
+            `gauss_flows.TimeFourier` gate. Ignored when ``time_net`` is
             provided.
 
     Raises:
@@ -58,9 +58,9 @@ class ContinuousAffineCoupling(AbstractBijection):
         - transform_and_log_det: (dim,) → (dim,), scalar log_det
         - inverse_and_log_det:   (dim,) → (dim,), scalar log_det
         (always takes a ``condition`` of shape ``(1 + control_dim,)`` packed as
-        ``[t, c]`` via :func:`gauss_flows.pack_time_control`)
+        ``[t, c]`` via `gauss_flows.pack_time_control`)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import ContinuousAffineCoupling, pack_time_control
@@ -158,7 +158,7 @@ class ContinuousAffineCoupling(AbstractBijection):
         Args:
             x: Single event of shape ``(dim,)``.
             condition: Packed ``[t, c]`` of shape ``(1 + control_dim,)`` (build
-                it with :func:`gauss_flows.pack_time_control`). Required.
+                it with `gauss_flows.pack_time_control`). Required.
 
         Returns:
             Tuple ``(y, log_det)`` with ``y`` of shape ``(dim,)`` and a scalar
@@ -186,7 +186,7 @@ class ContinuousAffineCoupling(AbstractBijection):
         Args:
             y: Single event of shape ``(dim,)``.
             condition: Packed ``[t, c]`` of shape ``(1 + control_dim,)`` (build
-                it with :func:`gauss_flows.pack_time_control`). Required.
+                it with `gauss_flows.pack_time_control`). Required.
 
         Returns:
             Tuple ``(x, log_det)`` with ``x`` of shape ``(dim,)`` and a scalar

--- a/src/gauss_flows/_src/transforms/bijections/coupling/deepsigmoid.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/deepsigmoid.py
@@ -29,7 +29,7 @@ class _DeepSigmoidTransformer(AbstractBijection):
         dy/dx = base_scale + Σᵢ amplitudesᵢ · slopesᵢ · σ(·) · (1 − σ(·))
 
     with ``base_scale``, ``amplitudes``, ``slopes`` constrained strictly
-    positive via :class:`paramax.Parameterize` wrapping ``softplus + 1e-4``
+    positive via `paramax.Parameterize` wrapping ``softplus + 1e-4``
     (mirrors the flowjax convention in ``RQSpline``, ``StudentT``, etc.).
     ``dy/dx > 0`` everywhere → strictly monotone, hence invertible. Matches
     the *single-layer* sigmoid flow of Huang et al. (2018) NAF, §3.2; it
@@ -38,8 +38,8 @@ class _DeepSigmoidTransformer(AbstractBijection):
     multi-modal targets and the loss surface tends to have a strong
     attractor at the affine local minimum (see PR #45).
 
-    The inverse solves ``y = _forward(x)`` via :func:`optimistix.root_find`
-    with :class:`optimistix.Bisection` — this gives ``expand_if_necessary``
+    The inverse solves ``y = _forward(x)`` via `optimistix.root_find`
+    with `optimistix.Bisection` — this gives ``expand_if_necessary``
     bracket growth and proper convergence handling, replacing the previous
     hand-rolled fori_loop bisection.
     """
@@ -129,7 +129,7 @@ class DeepSigmoidCoupling(AbstractBijection):
     """Coupling layer with a monotone single-layer sigmoidal transformer.
 
     Replaces ``AffineCoupling``'s affine transformer with the
-    :class:`_DeepSigmoidTransformer` — a per-dim monotone function
+    `_DeepSigmoidTransformer` — a per-dim monotone function
     parametrised by ``n_components`` sigmoid units (single-layer DSF, Huang
     et al. 2018 NAF §3.2). The transformer is *strictly more expressive*
     than affine in the function-class sense: it has nonzero second derivative
@@ -165,7 +165,7 @@ class DeepSigmoidCoupling(AbstractBijection):
         the coupling splits into ``n_dims // 2`` kept + transformed halves, and
         ``log_det`` sums ``log(dy/dx)`` over the transformed dims)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import DeepSigmoidCoupling

--- a/src/gauss_flows/_src/transforms/bijections/coupling/gin_coupling.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/gin_coupling.py
@@ -13,7 +13,7 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 def _center_log_scale(log_scale: Array) -> Array:
     """Center log-scales so ``Σᵢ log_scaleᵢ = 0`` in exact arithmetic.
 
-    In float32 the centering leaves ~1e-7 drift per layer; :class:`GINCoupling`
+    In float32 the centering leaves ~1e-7 drift per layer; `GINCoupling`
     returns a hardcoded zero ``log_det`` rather than ``jnp.sum`` of this tensor
     to keep the volume preservation drift-free through stacked layers.
     """
@@ -23,7 +23,7 @@ def _center_log_scale(log_scale: Array) -> Array:
 class GINCoupling(AbstractBijection):
     """Volume-preserving affine coupling from Sorrenson et al. (2020).
 
-    This matches :class:`AffineCoupling` except the active-half log-scales are
+    This matches `AffineCoupling` except the active-half log-scales are
     centred before exponentiation:
 
     ``y_active = x_active · exp(log_scale − mean(log_scale)) + shift``
@@ -59,7 +59,7 @@ class GINCoupling(AbstractBijection):
         - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det (≡ 0)
         (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import GINCoupling

--- a/src/gauss_flows/_src/transforms/bijections/coupling/mixture_cdf.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/mixture_cdf.py
@@ -9,9 +9,9 @@ mixture-CDF Gaussianization
     log |det J| = Σᵢ [log f_i(x_{b,i}) − log φ(z_{b,i})]
 
 The inverse is a per-dim monotone bisection on ``F_i(x_{b,i}) = Φ(z_{b,i})``.
-We solve it with :func:`optimistix.root_find` backed by
-:class:`optimistix.Bisection` with ``expand_if_necessary=True``, matching the
-convention already established for :class:`DeepSigmoidCoupling`.
+We solve it with `optimistix.root_find` backed by
+`optimistix.Bisection` with ``expand_if_necessary=True``, matching the
+convention already established for `DeepSigmoidCoupling`.
 """
 
 from __future__ import annotations
@@ -35,7 +35,7 @@ def _clamp_log_scale(raw: Array, bound: float) -> Array:
 
 
 def _invert_clamp_log_scale(clamped: ArrayLike, bound: float) -> Array:
-    """Invert :func:`_clamp_log_scale`. Used by IG warm-start init."""
+    """Invert `_clamp_log_scale`. Used by IG warm-start init."""
     y = jnp.clip(jnp.asarray(clamped) / bound, -1.0 + 1e-6, 1.0 - 1e-6)
     return jnp.arctanh(y)
 
@@ -45,7 +45,7 @@ class _MixtureGaussianCDFTransformer(AbstractBijection):
 
     A single-dim bijection ``z = Φ⁻¹(F(x; π, μ, σ))`` with trainable
     ``(logits, means, log_scales)``. Vectorised across dims by wrapping it
-    in :class:`flowjax.bijections.Coupling`.
+    in `flowjax.bijections.Coupling`.
     """
 
     n_components: int = eqx.field(static=True)
@@ -130,7 +130,7 @@ class MixtureGaussianCDFCoupling(AbstractBijection):
 
     The per-dim log-scales are passed through a tanh clamp
     ``bound · tanh(raw)`` for training stability and for RBIG warm-start
-    inversion — see :func:`gauss_flows._src.init.rbig.fit_rbig_coupling`.
+    inversion — see `gauss_flows._src.init.rbig.fit_rbig_coupling`.
 
     Args:
         key: JAX random key for the conditioner MLP.
@@ -154,7 +154,7 @@ class MixtureGaussianCDFCoupling(AbstractBijection):
         - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
         (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import MixtureGaussianCDFCoupling

--- a/src/gauss_flows/_src/transforms/bijections/coupling/spline.py
+++ b/src/gauss_flows/_src/transforms/bijections/coupling/spline.py
@@ -15,12 +15,12 @@ class RQSplineCoupling(AbstractBijection):
     ``n_dims // 2`` dims pass through unchanged and feed an inner conditioner
     MLP that emits the knot/derivative parameters of a monotone rational
     quadratic spline applied per-dim to the remaining half. Like
-    :class:`AffineCoupling` but with a far more expressive per-dim
+    `AffineCoupling` but with a far more expressive per-dim
     transformer; with ``cond_dim`` set, the inner MLP additionally consumes
     an external context vector concatenated onto the first-half input.
 
-    Wraps :class:`flowjax.bijections.Coupling` with a
-    :class:`flowjax.bijections.RationalQuadraticSpline` transformer; this
+    Wraps `flowjax.bijections.Coupling` with a
+    `flowjax.bijections.RationalQuadraticSpline` transformer; this
     class adds the convention that an unconditional layer drops any incoming
     ``condition`` so a base-only condition cannot leak into the inner MLP.
 
@@ -43,7 +43,7 @@ class RQSplineCoupling(AbstractBijection):
         - inverse_and_log_det:   (n_dims,) → (n_dims,), scalar log_det
         (with ``cond_dim`` set, also takes a ``condition`` of shape ``(cond_dim,)``)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import RQSplineCoupling

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/__init__.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/__init__.py
@@ -3,7 +3,7 @@
 Each transform in this subpackage acts independently on every dimension of
 its input — typically as a learned or fitted 1D CDF / inverse CDF. Used as
 the "marginal Gaussianization" half of RBIG-style flows and as drop-in
-pointwise layers inside a :class:`SurVAEFlow` chain.
+pointwise layers inside a `SurVAEFlow` chain.
 """
 
 from gauss_flows._src.transforms.bijections.elementwise.circular_spline import (

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/circular_spline.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/circular_spline.py
@@ -28,7 +28,7 @@ class CircularRationalQuadraticSpline(AbstractBijection):
     angular wrap boundary, matching the construction of Rezende et al. 2020,
     *Normalizing Flows on Tori and Spheres*.
 
-    Implementation: wraps :class:`flowjax.bijections.RationalQuadraticSpline` and
+    Implementation: wraps `flowjax.bijections.RationalQuadraticSpline` and
     replaces the ``derivatives`` Parameterize with a tied variant — one fewer
     free parameter than the unconstrained spline.
 
@@ -45,7 +45,7 @@ class CircularRationalQuadraticSpline(AbstractBijection):
         - transform_and_log_det: ``()`` → ``()``, scalar log_det
         - inverse_and_log_det:   ``()`` → ``()``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import CircularRationalQuadraticSpline
         >>> t = CircularRationalQuadraticSpline(knots=8)  # bound = π

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/histogram.py
@@ -25,7 +25,7 @@ class HistogramCDF(AbstractBijection):
     "outside the support of the fitted CDF").
 
     The CDF is built from an equal-width histogram and routed through an
-    :class:`interpax.Interpolator1D` per dimension. Two interpolation
+    `interpax.Interpolator1D` per dimension. Two interpolation
     strategies are supported:
 
     - ``method="linear"`` (default): piecewise-linear CDF. Bit-identical to
@@ -64,7 +64,7 @@ class HistogramCDF(AbstractBijection):
         - inverse_and_log_det:   ``(n_dims,)`` in ``[0, 1]`` → ``(n_dims,)``,
           scalar log_det
 
-    Example:
+    Examples:
         Fit and transform on Gaussian data:
 
         >>> import jax.numpy as jnp
@@ -120,7 +120,7 @@ class HistogramCDF(AbstractBijection):
                 estimate the marginal CDFs.
 
         Returns:
-            A new :class:`HistogramCDF` with concrete ``bin_edges``,
+            A new `HistogramCDF` with concrete ``bin_edges``,
             ``bin_pdf``, ``cdf_edges``, and per-dim forward/inverse
             interpolators populated. Idempotent: refitting with the same
             data yields the same fitted parameters.

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/inverse_gauss.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/inverse_gauss.py
@@ -29,7 +29,7 @@ class InverseGaussCDF(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import InverseGaussCDF
         >>> t = InverseGaussCDF(shape=(3,))

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/mixture_cdf.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/mixture_cdf.py
@@ -32,7 +32,7 @@ class MixtureGaussianCDF(AbstractBijection):
 
     Use as the marginal block of a Gaussianization / RBIG flow. Construct
     parameters at zero (uniform components) with ``MixtureGaussianCDF(...)``, or
-    data-adapt the means/scales to per-dim quantiles via :meth:`from_data`.
+    data-adapt the means/scales to per-dim quantiles via `from_data`.
 
     Args:
         n_components: Number of mixture components ``K`` per dimension.
@@ -42,7 +42,7 @@ class MixtureGaussianCDF(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import MixtureGaussianCDF
         >>> t = MixtureGaussianCDF(n_components=4, shape=(3,))
@@ -91,7 +91,7 @@ class MixtureGaussianCDF(AbstractBijection):
             n_components: Mixture components ``K``. Defaults to 8.
 
         Returns:
-            A :class:`MixtureGaussianCDF` with data-adapted means/log-scales.
+            A `MixtureGaussianCDF` with data-adapted means/log-scales.
         """
         import numpy as np
         from paramax.utils import inv_softplus
@@ -187,7 +187,7 @@ class MixtureGaussianCDF(AbstractBijection):
 class MixtureLogisticCDF(AbstractBijection):
     """Marginal Gaussianization via a mixture-of-logistics CDF.
 
-    Identical in structure to :class:`MixtureGaussianCDF` but each per-dim
+    Identical in structure to `MixtureGaussianCDF` but each per-dim
     mixture component is logistic rather than Gaussian: the component CDF is the
     sigmoid ``σ((x − μ) / s)``. Maps each dimension through its logistic-mixture
     CDF (→ uniform on ``[0, 1]``) then through the inverse normal CDF (probit).
@@ -203,7 +203,7 @@ class MixtureLogisticCDF(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import MixtureLogisticCDF
         >>> t = MixtureLogisticCDF(n_components=4, shape=(3,))

--- a/src/gauss_flows/_src/transforms/bijections/elementwise/spline.py
+++ b/src/gauss_flows/_src/transforms/bijections/elementwise/spline.py
@@ -1,7 +1,7 @@
 """Marginal rational quadratic spline bijection.
 
 Applies a per-dim RQ spline independently — the elementwise counterpart
-of :class:`RQSplineCoupling`.
+of `RQSplineCoupling`.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ class RQSplineMarginal(AbstractBijection):
 
     Applies a monotonic rational-quadratic spline (Durkan et al. 2019,
     *Neural Spline Flows*) independently to each dimension — the elementwise
-    counterpart of :class:`RQSplineCoupling`. Each dim gets its own ``n_bins``
+    counterpart of `RQSplineCoupling`. Each dim gets its own ``n_bins``
     knots over the symmetric interval ``[−interval, interval]``; outside that
     interval the map is the identity (linear tails). Inputs should lie within
     the interval for the spline to act non-trivially.
@@ -33,7 +33,7 @@ class RQSplineMarginal(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import RQSplineMarginal
         >>> t = RQSplineMarginal(n_bins=8, shape=(3,), interval=5.0)

--- a/src/gauss_flows/_src/transforms/bijections/linear/conv1x1.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/conv1x1.py
@@ -34,7 +34,7 @@ class Invertible1x1Conv(AbstractBijection):
         - transform_and_log_det: ``(n_channels,)`` → ``(n_channels,)``, scalar log_det
         - inverse_and_log_det:   ``(n_channels,)`` → ``(n_channels,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import Invertible1x1Conv

--- a/src/gauss_flows/_src/transforms/bijections/linear/conv_exp.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/conv_exp.py
@@ -14,106 +14,103 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 class OrthogonalConvExponential(AbstractBijection):
     r"""Orthogonal convolution via the exponential of a skew-symmetric operator.
 
-    Motivation
-    ----------
+    **Motivation**
     Glow-style image flows need an invertible linear mixer across pixels *and*
     channels whose log-determinant is cheap to evaluate. A convolution with a
     spatially-extended kernel has the desired receptive field, but is not
     invertible in general. The convolution exponential (Hoogeboom et al., 2020)
-    lifts a possibly non-invertible conv operator :math:`M` to
+    lifts a possibly non-invertible conv operator $M$ to
 
-    .. math::
+    $$
+    \exp(M) \;=\; \sum_{k=0}^{\infty} \frac{M^k}{k!},
+    $$
 
-        \exp(M) \;=\; \sum_{k=0}^{\infty} \frac{M^k}{k!},
-
-    which is *always* invertible (its inverse is :math:`\exp(-M)`). Taking
-    :math:`M` skew-symmetric (:math:`M^\top = -M`) further makes :math:`\exp(M)`
+    which is *always* invertible (its inverse is $\exp(-M)$). Taking
+    $M$ skew-symmetric ($M^\top = -M$) further makes $\exp(M)$
     an **orthogonal** matrix, so the bijection is norm-preserving and has
-    Jacobian determinant exactly :math:`+1`.
+    Jacobian determinant exactly $+1$.
 
-    Construction
-    ------------
-    **1. Skew-symmetric conv operator.** For a :math:`(k_h, k_w, C, C)` kernel
-    :math:`K` indexed relative to its center, the induced circular-convolution
-    Toeplitz operator :math:`M_K` acting on flattened images has the transpose
+    **Construction**
+    **1. Skew-symmetric conv operator.** For a $(k_h, k_w, C, C)$ kernel
+    $K$ indexed relative to its center, the induced circular-convolution
+    Toeplitz operator $M_K$ acting on flattened images has the transpose
 
-    .. math::
+    $$
+    (M_K^\top)_{p,q} \;=\; K[k_h{-}1{-}i,\,k_w{-}1{-}j,\,b,\,a]\quad
+        \text{when}\quad
+    (M_K)_{p,q} \;=\; K[i,\,j,\,a,\,b].
+    $$
 
-        (M_K^\top)_{p,q} \;=\; K[k_h{-}1{-}i,\,k_w{-}1{-}j,\,b,\,a]\quad
-            \text{when}\quad
-        (M_K)_{p,q} \;=\; K[i,\,j,\,a,\,b].
+    Skew-symmetry $M_K = -M_K^\top$ therefore holds iff
 
-    Skew-symmetry :math:`M_K = -M_K^\top` therefore holds iff
+    $$
+    K[i, j, a, b] \;=\; -\,K[k_h{-}1{-}i,\,k_w{-}1{-}j,\,b,\,a].
+    $$
 
-    .. math::
+    We enforce this exactly by setting $K = W - \widetilde{W}$ where
+    $\widetilde{W}[i,j,a,b] = W[k_h{-}1{-}i,\,k_w{-}1{-}j,\,b,\,a]$
+    (flip spatial axes + swap input/output channels). See `_skew`.
 
-        K[i, j, a, b] \;=\; -\,K[k_h{-}1{-}i,\,k_w{-}1{-}j,\,b,\,a].
+    **2. Truncated Taylor series.** The forward map applies $\exp(M_K)$
+    via the $N$-term truncation
 
-    We enforce this exactly by setting :math:`K = W - \widetilde{W}` where
-    :math:`\widetilde{W}[i,j,a,b] = W[k_h{-}1{-}i,\,k_w{-}1{-}j,\,b,\,a]`
-    (flip spatial axes + swap input/output channels). See :meth:`_skew`.
+    $$
+    p_N(M_K)\,x
+        \;=\; \sum_{k=0}^{N} \frac{M_K^k\, x}{k!}
+        \;=\; \bigl(I + M_K + \tfrac{1}{2!}M_K^2 + \dots\bigr)\,x,
+    $$
 
-    **2. Truncated Taylor series.** The forward map applies :math:`\exp(M_K)`
-    via the :math:`N`-term truncation
+    which we compute with a `jax.lax.scan` using a separate
+    Taylor-term accumulator $t_k$: starting from
+    $t_0 = r_0 = x$, we update
 
-    .. math::
+    $$
+    t_{k+1} \;=\; \frac{1}{k+1}\, M_K\, t_k, \qquad
+    r_{k+1} \;=\; r_k + t_{k+1},
+    $$
 
-        p_N(M_K)\,x
-            \;=\; \sum_{k=0}^{N} \frac{M_K^k\, x}{k!}
-            \;=\; \bigl(I + M_K + \tfrac{1}{2!}M_K^2 + \dots\bigr)\,x,
+    so that $r_N = p_N(M_K)\,x$ (see
+    `_convolution_exponential`). The truncation error is
 
-    which we compute with a :func:`jax.lax.scan` using a separate
-    Taylor-term accumulator :math:`t_k`: starting from
-    :math:`t_0 = r_0 = x`, we update
-
-    .. math::
-
-        t_{k+1} \;=\; \frac{1}{k+1}\, M_K\, t_k, \qquad
-        r_{k+1} \;=\; r_k + t_{k+1},
-
-    so that :math:`r_N = p_N(M_K)\,x` (see
-    :meth:`_convolution_exponential`). The truncation error is
-
-    .. math::
-
-        \lVert p_N(M) - \exp(M) \rVert
-            \;=\; \mathcal{O}\!\bigl(\|M\|^{N+1}/(N{+}1)!\bigr),
+    $$
+    \lVert p_N(M) - \exp(M) \rVert
+        \;=\; \mathcal{O}\!\bigl(\|M\|^{N+1}/(N{+}1)!\bigr),
+    $$
 
     so with ``n_terms = 8`` and ``||M|| <= 1`` the residual is below
-    :math:`1/9! \approx 2.8\times 10^{-6}`.
+    $1/9! \approx 2.8\times 10^{-6}$.
 
-    **3. Spectral normalization.** To keep :math:`\|M_K\| \leq 1`, we estimate
+    **3. Spectral normalization.** To keep $\|M_K\| \leq 1$, we estimate
     the operator norm via image-space power iteration and divide by
-    :math:`\max(\sigma, 1)`. Gradients are blocked through the
-    :math:`\sigma`-estimate (:func:`jax.lax.stop_gradient`), so training does
+    $\max(\sigma, 1)$. Gradients are blocked through the
+    $\sigma$-estimate (`jax.lax.stop_gradient`), so training does
     *not* differentiate through the power iteration itself — only through the
-    explicit ``kernel / sigma`` rescale. See :meth:`_spectral_normalize`.
+    explicit ``kernel / sigma`` rescale. See `_spectral_normalize`.
 
-    **4. Log-determinant.** Because :math:`M_K` is skew-symmetric its trace
+    **4. Log-determinant.** Because $M_K$ is skew-symmetric its trace
     vanishes, and
 
-    .. math::
-
-        \log\!\bigl|\det \exp(M_K)\bigr|
-            \;=\; \operatorname{tr}(M_K) \;=\; 0
+    $$
+    \log\!\bigl|\det \exp(M_K)\bigr|
+        \;=\; \operatorname{tr}(M_K) \;=\; 0
+    $$
 
     exactly. We return ``jnp.zeros(())`` — the truncated operator's log-det
-    differs from this by :math:`\mathcal{O}(\|M\|^{N+1}/(N{+}1)!)`, the same
+    differs from this by $\mathcal{O}(\|M\|^{N+1}/(N{+}1)!)$, the same
     negligible quantity as the round-trip residual.
 
-    **5. Inverse.** Since :math:`\exp(M)^{-1} = \exp(-M)` for any :math:`M`,
+    **5. Inverse.** Since $\exp(M)^{-1} = \exp(-M)$ for any $M$,
     the inverse applies the same truncated series with negated kernel.
-    Composing :math:`p_N(-M_K)\circ p_N(M_K)` leaves an
-    :math:`\mathcal{O}(\|M\|^{N+1}/(N{+}1)!)` residual, acceptable for any
-    reasonable :math:`N`.
+    Composing $p_N(-M_K)\circ p_N(M_K)$ leaves an
+    $\mathcal{O}(\|M\|^{N+1}/(N{+}1)!)$ residual, acceptable for any
+    reasonable $N$.
 
-    Shapes
-    ------
-    ::
-
-        x, y                     : (H, W, C)
-        weight / skew kernel K   : (k_h, k_w, C, C) in flowjax/JAX HWIO
-        log_det                  : ()                 (scalar, always 0)
+    **Shapes**
+    ```python
+    x, y                     : (H, W, C)
+    weight / skew kernel K   : (k_h, k_w, C, C) in flowjax/JAX HWIO
+    log_det                  : ()                 (scalar, always 0)
+    ```
 
     Args:
         key: JAX random key for kernel initialization.
@@ -121,12 +118,12 @@ class OrthogonalConvExponential(AbstractBijection):
         kernel_size: Spatial kernel size (must be a positive **odd** integer
             so the kernel has a unique center pixel).
         n_terms: Number of Taylor-series terms ``N`` (``>= 1``). Truncation
-            error scales as :math:`\mathcal{O}(1 / (N{+}1)!)`.
+            error scales as $\mathcal{O}(1 / (N{+}1)!)$.
         n_power_iterations: Power-iteration steps for the spectral-norm
             estimate (``>= 1``). Two iterations is usually enough because
-            :math:`\sigma` only needs an upper bound, not high accuracy.
+            $\sigma$ only needs an upper bound, not high accuracy.
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> key = jr.key(0)
@@ -202,13 +199,13 @@ class OrthogonalConvExponential(AbstractBijection):
 
         Given free parameter ``W`` of shape ``(k_h, k_w, C, C)``, returns
 
-        .. math::
-
-            K \;=\; W \,-\, \widetilde{W},\qquad
-            \widetilde{W}[i, j, a, b] \;=\; W[k_h{-}1{-}i,\,k_w{-}1{-}j,\,b,\,a].
+        $$
+        K \;=\; W \,-\, \widetilde{W},\qquad
+        \widetilde{W}[i, j, a, b] \;=\; W[k_h{-}1{-}i,\,k_w{-}1{-}j,\,b,\,a].
+        $$
 
         Under circular padding, the induced Toeplitz operator ``M_K`` satisfies
-        :math:`M_K = -M_K^\top`, so :math:`\exp(M_K)` is orthogonal.
+        $M_K = -M_K^\top$, so $\exp(M_K)$ is orthogonal.
 
         Shape:
             ``weight``: ``(k_h, k_w, C, C)``
@@ -224,7 +221,7 @@ class OrthogonalConvExponential(AbstractBijection):
 
         Pads ``x`` with wrap-mode boundary so that VALID-padded convolution
         produces the circular (periodic) result, then delegates to
-        :func:`jax.lax.conv_general_dilated` with NHWC/HWIO layout.
+        `jax.lax.conv_general_dilated` with NHWC/HWIO layout.
 
         Shape:
             ``x``      : ``(H, W, C_in)``
@@ -248,9 +245,9 @@ class OrthogonalConvExponential(AbstractBijection):
     def _circular_conv_transpose(self, x: Array, kernel: Array) -> Array:
         r"""Mathematical transpose (adjoint) of circular conv.
 
-        For a circular conv with kernel :math:`K` the operator adjoint is the
+        For a circular conv with kernel $K$ the operator adjoint is the
         circular conv with the *index-flipped, channel-transposed* kernel
-        :math:`K^\top[i, j, o, c] = K[k_h{-}1{-}i, k_w{-}1{-}j, c, o]`.
+        $K^\top[i, j, o, c] = K[k_h{-}1{-}i, k_w{-}1{-}j, c, o]$.
 
         Shape:
             ``x``      : ``(H, W, C_out)``
@@ -264,30 +261,30 @@ class OrthogonalConvExponential(AbstractBijection):
     def _spectral_normalize(self, kernel: Array) -> Array:
         r"""Clip kernel spectral norm to at most 1 via power iteration.
 
-        Estimates :math:`\sigma \approx \|M_K\|_{op}` using the standard SVD
-        power iteration in image space: alternately apply :math:`M_K` and
-        :math:`M_K^\top`, renormalizing after each step. The estimate is
-        wrapped in :func:`jax.lax.stop_gradient` so backprop does *not*
+        Estimates $\sigma \approx \|M_K\|_{op}$ using the standard SVD
+        power iteration in image space: alternately apply $M_K$ and
+        $M_K^\top$, renormalizing after each step. The estimate is
+        wrapped in `jax.lax.stop_gradient` so backprop does *not*
         differentiate through the iteration itself — gradients flow only
         through the explicit ``kernel / sigma`` rescale.
 
-        After :math:`n` iterations, :math:`\sigma` converges to
-        :math:`\sigma_1 = \|M_K\|` with ratio :math:`(\sigma_2/\sigma_1)^n`.
+        After $n$ iterations, $\sigma$ converges to
+        $\sigma_1 = \|M_K\|$ with ratio $(\sigma_2/\sigma_1)^n$.
         Two iterations suffice because we only need an *upper bound* (we
-        take :math:`\max(\sigma, 1)`), not high accuracy.
+        take $\max(\sigma, 1)$), not high accuracy.
 
         **Seed choice.** The seed must have non-zero projection on the
-        leading singular vector of :math:`M_K`. Any *deterministic* seed
-        (constant, :math:`\sin(\text{arange})`, ...) can collide with
-        :math:`\ker(M_K)` for specific kernel configurations — e.g. a
-        constant vector is in :math:`\ker(M_K)` for skew-symmetric kernels
-        with :math:`C = 1`, and any fixed pattern in :math:`\mathbb{R}^3`
+        leading singular vector of $M_K$. Any *deterministic* seed
+        (constant, $\sin(\text{arange})$, ...) can collide with
+        $\ker(M_K)$ for specific kernel configurations — e.g. a
+        constant vector is in $\ker(M_K)$ for skew-symmetric kernels
+        with $C = 1$, and any fixed pattern in $\mathbb{R}^3$
         can land in the 1-D nullspace of a ``shape=(1,1,3)`` +
         ``kernel_size=1`` skew kernel. We therefore use a **persistent
         random** seed stored at construction time
-        (:attr:`spectral_seed`). A random Gaussian has non-zero projection
+        (`spectral_seed`). A random Gaussian has non-zero projection
         on every fixed direction with probability 1, so alignment with
-        :math:`\ker(M_K)` over the kernel trajectory during training is
+        $\ker(M_K)$ over the kernel trajectory during training is
         measure-zero.
 
         Shape:
@@ -325,20 +322,20 @@ class OrthogonalConvExponential(AbstractBijection):
         return kernel / (scale + 1e-8)  # (k_h, k_w, C, C)
 
     def _convolution_exponential(self, x: Array, kernel: Array) -> Array:
-        r"""Apply the truncated matrix exponential :math:`p_N(M_K)\,x`.
+        r"""Apply the truncated matrix exponential $p_N(M_K)\,x$.
 
         Computes the partial Taylor sum
 
-        .. math::
+        $$
+        r_N \;=\; \sum_{k=0}^{N} \frac{M_K^k\, x}{k!},
+        $$
 
-            r_N \;=\; \sum_{k=0}^{N} \frac{M_K^k\, x}{k!},
-
-        via the recurrence :math:`t_0 = x`, :math:`t_{k+1} = \tfrac{1}{k+1} M_K\, t_k`,
-        :math:`r_{k+1} = r_k + t_{k+1}`. Each iteration costs one circular conv
+        via the recurrence $t_0 = x$, $t_{k+1} = \tfrac{1}{k+1} M_K\, t_k$,
+        $r_{k+1} = r_k + t_{k+1}$. Each iteration costs one circular conv
         (``O(H W k_h k_w C^2)``); total cost scales linearly in ``n_terms``.
 
         Shape:
-            ``x``, ``kernel``, returns as in :meth:`_circular_conv`.
+            ``x``, ``kernel``, returns as in `_circular_conv`.
         """
 
         def body(carry, i):
@@ -352,7 +349,7 @@ class OrthogonalConvExponential(AbstractBijection):
         return result  # (H, W, C)
 
     def transform_and_log_det(self, x: ArrayLike, condition=None):
-        """Forward map :math:`y = \\exp(M_K)\\,x` and scalar log-det (=0).
+        """Forward map $y = \\exp(M_K)\\,x$ and scalar log-det (=0).
 
         Shape:
             ``x``    : ``(H, W, C)``
@@ -366,9 +363,9 @@ class OrthogonalConvExponential(AbstractBijection):
         return y, jnp.zeros(())
 
     def inverse_and_log_det(self, y: ArrayLike, condition=None):
-        """Inverse map :math:`x = \\exp(-M_K)\\,y` and scalar log-det (=0).
+        """Inverse map $x = \\exp(-M_K)\\,y$ and scalar log-det (=0).
 
-        Uses the identity :math:`\\exp(M)^{-1} = \\exp(-M)` — truncated at
+        Uses the identity $\\exp(M)^{-1} = \\exp(-M)$ — truncated at
         the same ``n_terms`` as forward, so the round-trip residual is
         ``O(||M||^{n_terms+1} / (n_terms+1)!)``.
 

--- a/src/gauss_flows/_src/transforms/bijections/linear/haar.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/haar.py
@@ -34,7 +34,7 @@ class HaarWavelet(AbstractBijection):
         - transform_and_log_det: ``(…, n)`` → ``(…, n)``, scalar log_det = −n·log 2
         - inverse_and_log_det:   ``(…, n)`` → ``(…, n)``, scalar log_det = +n·log 2
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import HaarWavelet
         >>> t = HaarWavelet(shape=(4,))

--- a/src/gauss_flows/_src/transforms/bijections/linear/lu.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/lu.py
@@ -17,7 +17,7 @@ class LULinearPermute(AbstractBijection):
     positive diagonal (parameterised as ``exp(log_diag)``). The log-absolute
     determinant reduces to ``sum(log_diag)``, avoiding an explicit Jacobian.
 
-    Cheaper than :class:`OrthogonalRotation` in the relevant regime (no Cayley
+    Cheaper than `OrthogonalRotation` in the relevant regime (no Cayley
     solve at forward / inverse time) and widely used as the mixing layer in
     Neural Spline Flows (Durkan et al. 2019, *Neural Spline Flows*).
 
@@ -36,7 +36,7 @@ class LULinearPermute(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import LULinearPermute
         >>> t = LULinearPermute(shape=(3,))  # reverse permutation

--- a/src/gauss_flows/_src/transforms/bijections/linear/matrix_exponential.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/matrix_exponential.py
@@ -41,15 +41,15 @@ class MatrixExponential(AbstractBijection):
         w_init_scale: Standard deviation used to initialise ``W`` and ``b``.
         use_bias: If ``False``, drop the ``h(t) · b`` term.
         time_bias_net: Optional scalar time gate ``h`` with ``h(0) = 0``.
-            Defaults to :class:`gauss_flows.TimeIdentity` when ``use_bias=True``.
+            Defaults to `gauss_flows.TimeIdentity` when ``use_bias=True``.
 
     Shape:
         - Input ``x``: ``(dim,)``
-        - Condition: packed time ``(1,)`` from :func:`gauss_flows.pack_time_control`
+        - Condition: packed time ``(1,)`` from `gauss_flows.pack_time_control`
         - Output ``y``: ``(dim,)``
         - ``log_det``: scalar ``()``
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import MatrixExponential, pack_time_control

--- a/src/gauss_flows/_src/transforms/bijections/linear/orthogonal_conv1x1.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/orthogonal_conv1x1.py
@@ -22,10 +22,10 @@ class Orthogonal1x1Conv(AbstractBijection):
     ``y = Q·x``; the inverse is ``x = Q.T·y``; ``log|det Q| = 0`` (volume-
     preserving). Callers that operate on ``(H, W, C)`` image events should
     vmap externally — this matches the single-event convention shared with
-    :class:`Invertible1x1Conv` and the rest of the package (see
+    `Invertible1x1Conv` and the rest of the package (see
     ``CLAUDE.md``).
 
-    **Learnable path** (default): delegates to :class:`OrthogonalRotation`'s
+    **Learnable path** (default): delegates to `OrthogonalRotation`'s
     Cayley parameterisation ``Q = (I − A)(I + A)^{-1}`` with skew-symmetric
     ``A``. Unlike ``OrthogonalRotation``'s zero init (which starts at
     ``Q = I``), this class re-initialises the skew parameters with small
@@ -35,29 +35,30 @@ class Orthogonal1x1Conv(AbstractBijection):
 
     **Fixed path** (``fixed_matrix`` supplied): holds Q constant at the
     supplied matrix. ``fixed_matrix`` is wrapped in
-    :class:`paramax.NonTrainable` so the standard flowjax training loops
+    `paramax.NonTrainable` so the standard flowjax training loops
     (``flowjax.train.fit_to_data`` and friends) and any
     ``eqx.filter(model, eqx.is_inexact_array)``-based optimizer-filter
     combined with ``paramax.unwrap`` treat the matrix as frozen; the
     wrapper also applies ``jax.lax.stop_gradient`` to the inner array
-    every time :meth:`_get_rotation_matrix` unwraps the module.
+    every time `_get_rotation_matrix` unwraps the module.
 
-    .. warning::
+    !!! warning
         **Decoupled weight decay bypasses `NonTrainable`.** Optimizers that
         update parameters from the parameter *value* (e.g. ``optax.adamw``
         with a non-zero ``weight_decay``) will still drift ``fixed_matrix``
         away from orthogonality because weight decay does not go through
         the gradient path. To keep ``fixed_matrix`` bit-identical under
         ``adamw``-style training, partition it out of the optimizer state
-        before updating::
-
-            trainable, frozen = eqx.partition(
-                model,
-                lambda leaf: eqx.is_inexact_array(leaf)
-                and not isinstance(leaf, paramax.NonTrainable),
-                is_leaf=lambda leaf: isinstance(leaf, paramax.NonTrainable),
-            )
-            # optimize `trainable`, recombine with `frozen` at step end.
+        before updating:
+        ```python
+        trainable, frozen = eqx.partition(
+            model,
+            lambda leaf: eqx.is_inexact_array(leaf)
+            and not isinstance(leaf, paramax.NonTrainable),
+            is_leaf=lambda leaf: isinstance(leaf, paramax.NonTrainable),
+        )
+        # optimize `trainable`, recombine with `frozen` at step end.
+        ```
 
     Args:
         key: PRNG key used for learnable Cayley initialisation. Ignored
@@ -82,16 +83,16 @@ class Orthogonal1x1Conv(AbstractBijection):
 
     Note:
         The public surface is a superset of
-        :class:`OrthogonalRotation`: the learnable path produces the same
+        `OrthogonalRotation`: the learnable path produces the same
         family of orthogonal matrices (same ``skew_params`` shape, same
         Cayley map), with a more flow-literature-friendly name and a
         genuinely-fixed alternative branch. Prefer
-        :class:`OrthogonalRotation` if you want the exact zero-init
+        `OrthogonalRotation` if you want the exact zero-init
         (``Q = I`` at step 0) used by classic RBIG flows; prefer this
         class when small-random init or a pre-computed fixed rotation is
         wanted.
 
-    Example:
+    Examples:
         Learnable (Cayley-parameterised, near-identity init):
 
         >>> import jax.numpy as jnp

--- a/src/gauss_flows/_src/transforms/bijections/linear/rotation.py
+++ b/src/gauss_flows/_src/transforms/bijections/linear/rotation.py
@@ -38,7 +38,7 @@ class HouseholderRotation(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import HouseholderRotation
         >>> t = HouseholderRotation(n_reflections=2, shape=(3,))
@@ -103,7 +103,7 @@ class OrthogonalRotation(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import OrthogonalRotation
         >>> t = OrthogonalRotation(shape=(3,))  # Q = I at init
@@ -154,16 +154,16 @@ class FixedRotation(AbstractBijection):
     """Fixed (non-trainable) orthogonal rotation matrix.
 
     Applies a pre-computed orthogonal matrix ``y = matrix·x`` (e.g. a PCA
-    rotation from :meth:`from_data`) that is held constant during training.
+    rotation from `from_data`) that is held constant during training.
     Orthogonality makes the map volume-preserving, so ``log_det = 0`` exactly
     and the inverse is the transpose.
 
-    The matrix is stored wrapped in :class:`paramax.NonTrainable` so
+    The matrix is stored wrapped in `paramax.NonTrainable` so
     ``flowjax.train.fit_to_data`` skips it during gradient descent — without
     the wrapper Adam drifts the rows off the orthogonal manifold and sampling
     silently collapses while ``log_prob`` keeps reporting plausible numbers.
     The public ``matrix`` property transparently returns the unwrapped
-    :class:`jax.Array` so downstream code can still do ``rot.matrix @ x``.
+    `jax.Array` so downstream code can still do ``rot.matrix @ x``.
 
     Operates on a single ``(n_dims,)`` event; callers vmap over any batch axis.
 
@@ -177,7 +177,7 @@ class FixedRotation(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det = 0
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
         >>> from gauss_flows import FixedRotation
@@ -228,7 +228,7 @@ class FixedRotation(AbstractBijection):
             x: Training data of shape ``(n, d)``.
 
         Returns:
-            A :class:`FixedRotation` whose matrix is the PCA rotation of ``x``.
+            A `FixedRotation` whose matrix is the PCA rotation of ``x``.
         """
         x = jnp.asarray(x, dtype=float)
         if x.ndim != 2:

--- a/src/gauss_flows/_src/transforms/bijections/normalization/actnorm.py
+++ b/src/gauss_flows/_src/transforms/bijections/normalization/actnorm.py
@@ -35,7 +35,7 @@ class ActNorm(AbstractBijection):
         - transform_and_log_det: ``(..., C)`` → ``(..., C)``, scalar log_det
         - inverse_and_log_det:   ``(..., C)`` → ``(..., C)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import ActNorm
         >>> layer = ActNorm(shape=(4, 4, 3))
@@ -79,7 +79,7 @@ class ActNorm(AbstractBijection):
 class ActNorm1D(AbstractBijection):
     """Activation normalization (ActNorm) for 1-D events.
 
-    The 1-D specialisation of :class:`ActNorm` used inside the coupling-flow
+    The 1-D specialisation of `ActNorm` used inside the coupling-flow
     stack where there are no spatial axes. Applies a per-dimension affine map
     ``y = (x − loc) / scale`` with positive ``scale = softplus(log_scale) +
     1e-5``. Unlike batch normalization, the parameters are learned and not
@@ -95,7 +95,7 @@ class ActNorm1D(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import ActNorm1D
         >>> layer = ActNorm1D(shape=(3,))

--- a/src/gauss_flows/_src/transforms/bijections/normalization/batchnorm.py
+++ b/src/gauss_flows/_src/transforms/bijections/normalization/batchnorm.py
@@ -59,7 +59,7 @@ class BatchNorm(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax
         >>> import jax.numpy as jnp
         >>> import jax.random as jr
@@ -70,22 +70,24 @@ class BatchNorm(AbstractBijection):
         >>> y.shape, log_det.shape
         ((2,), ())
 
-        Training step pattern (per batch)::
+        Training step pattern (per batch):
+        ```python
+        @eqx.filter_value_and_grad
+        def loss_fn(layer, x):
+            _, log_dets = jax.vmap(layer.transform_and_log_det)(x)
+            return -jnp.mean(log_dets)
 
-            @eqx.filter_value_and_grad
-            def loss_fn(layer, x):
-                _, log_dets = jax.vmap(layer.transform_and_log_det)(x)
-                return -jnp.mean(log_dets)
+        bn = bn.with_batch_stats_from_data(batch)           # set source
+        loss, grads = loss_fn(bn, batch)
+        bn = eqx.apply_updates(bn, jax.tree.map(lambda g: -1e-3 * g, grads))
+        bn = bn.update_running_stats_from_batch(batch)      # update EMA
+        ```
 
-            bn = bn.with_batch_stats_from_data(batch)           # set source
-            loss, grads = loss_fn(bn, batch)
-            bn = eqx.apply_updates(bn, jax.tree.map(lambda g: -1e-3 * g, grads))
-            bn = bn.update_running_stats_from_batch(batch)      # update EMA
-
-        Evaluation::
-
-            bn_eval = bn.with_running_average(True)
-            y, _ = jax.vmap(bn_eval.transform_and_log_det)(batch)
+        Evaluation:
+        ```python
+        bn_eval = bn.with_running_average(True)
+        y, _ = jax.vmap(bn_eval.transform_and_log_det)(batch)
+        ```
     """
 
     shape: tuple[int, ...]

--- a/src/gauss_flows/_src/transforms/bijections/periodic/_utils.py
+++ b/src/gauss_flows/_src/transforms/bijections/periodic/_utils.py
@@ -1,7 +1,7 @@
 """Shared helpers for periodic / circular bijections.
 
-Used by :mod:`.shift`, :mod:`.wrap`, and
-:mod:`...coupling.circular_spline` — kept in one place so the wrapping
+Used by `.shift`, `.wrap`, and
+`...coupling.circular_spline` — kept in one place so the wrapping
 primitives remain consistent across every transform that treats an input
 dim as living on the circle.
 """

--- a/src/gauss_flows/_src/transforms/bijections/periodic/shift.py
+++ b/src/gauss_flows/_src/transforms/bijections/periodic/shift.py
@@ -39,7 +39,7 @@ class PeriodicShift(AbstractBijection):
         - transform_and_log_det: ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import PeriodicShift
         >>> shift = PeriodicShift(ind=(0,), shape=(2,), shift_init=0.25)

--- a/src/gauss_flows/_src/transforms/bijections/periodic/wrap.py
+++ b/src/gauss_flows/_src/transforms/bijections/periodic/wrap.py
@@ -21,7 +21,7 @@ class PeriodicWrap(AbstractBijection):
     Wraps the chosen periodic dimensions into the canonical interval
     ``[−bound, bound]`` and leaves all other dimensions untouched.
 
-    .. warning::
+    !!! warning
         This subclasses ``flowjax.bijections.AbstractBijection`` for API
         compatibility but is **not a true bijection on ℝ** — it is a
         many-to-one canonical projection. ``x`` and ``x + 2·bound·k`` collapse
@@ -48,7 +48,7 @@ class PeriodicWrap(AbstractBijection):
         - inverse_and_log_det:   ``(n_dims,)`` → ``(n_dims,)``, scalar log_det
           (returns the wrapped value, not the original ``x``; see warning)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import PeriodicWrap
         >>> wrap = PeriodicWrap(ind=(0,), shape=(2,))

--- a/src/gauss_flows/_src/transforms/bijections/reshape/squeeze.py
+++ b/src/gauss_flows/_src/transforms/bijections/reshape/squeeze.py
@@ -36,7 +36,7 @@ class Squeeze(AbstractBijection):
         - transform_and_log_det: ``shape`` → ``out_shape``, scalar log_det (0)
         - inverse_and_log_det:   ``out_shape`` → ``shape``, scalar log_det (0)
 
-    Example:
+    Examples:
         >>> import jax.numpy as jnp
         >>> from gauss_flows import Squeeze
         >>> layer = Squeeze(shape=(4, 3))

--- a/src/gauss_flows/_src/transforms/stochastic/__init__.py
+++ b/src/gauss_flows/_src/transforms/stochastic/__init__.py
@@ -2,9 +2,9 @@
 
 A "stochastic transform" in the SurVAE hierarchy is one where ``forward``
 and ``inverse`` are both random — neither direction is a deterministic
-function of its input. The two canonical examples ship here: :class:`VAE`
+function of its input. The two canonical examples ship here: `VAE`
 (encoder / decoder pair as a single chain link) and
-:class:`StochasticPermutation` (uniform draw from the symmetric group).
+`StochasticPermutation` (uniform draw from the symmetric group).
 """
 
 from gauss_flows._src.transforms.stochastic.permutation import StochasticPermutation

--- a/src/gauss_flows/_src/transforms/stochastic/permutation.py
+++ b/src/gauss_flows/_src/transforms/stochastic/permutation.py
@@ -37,7 +37,7 @@ class StochasticPermutation(AbstractStochastic):
         - Output ``z``: ``shape`` (a permutation of ``x`` along ``axis``)
         - ``log_det``: scalar (shape ``()``)
 
-    Example:
+    Examples:
         Permute a 1D event:
 
         >>> import jax.numpy as jnp

--- a/src/gauss_flows/_src/transforms/stochastic/vae.py
+++ b/src/gauss_flows/_src/transforms/stochastic/vae.py
@@ -16,30 +16,32 @@ class VAE(AbstractStochastic):
     r"""Variational autoencoder as a SurVAE stochastic transform.
 
     Wraps an encoder ``q(z | x)`` and decoder ``p(x | z)`` so that a VAE
-    becomes a single link in a :class:`SurVAEFlow` chain. Stacking ``N`` of
+    becomes a single link in a `SurVAEFlow` chain. Stacking ``N`` of
     these yields an ``N``-level HVAE with no bespoke container code — the
     chain machinery already handles key splitting and ELBO accumulation.
 
-    Forward (data → latent, used inside ``log_prob``)::
-
-        z ~ q(z | x)
-        log_det = log p(x | z) − log q(z | x)
+    Forward (data → latent, used inside ``log_prob``):
+    ```python
+    z ~ q(z | x)
+    log_det = log p(x | z) − log q(z | x)
+    ```
 
     The forward ``log_det`` is exactly the per-event ELBO contribution of a
     single stochastic lift (Nielsen et al. 2020, eq. 7): together with the
     base-distribution term ``log p(z)`` it yields the standard ELBO
     ``E_q[log p(x|z) + log p(z) − log q(z|x)]``.
 
-    Inverse (latent → data, used for generation)::
-
-        x ~ p(x | z)
-        log_det = 0   (inverse is not consumed by ``log_prob``)
+    Inverse (latent → data, used for generation):
+    ```python
+    x ~ p(x | z)
+    log_det = 0   (inverse is not consumed by ``log_prob``)
+    ```
 
     Args:
         encoder: Conditional distribution ``q(z | x)``. Must expose
             ``sample(key, *, condition)`` and
             ``log_prob(value, *, condition)`` — the
-            :class:`ConditionalDistribution` protocol. **``sample`` must
+            `ConditionalDistribution` protocol. **``sample`` must
             be reparameterized** (e.g. location–scale Gaussian with
             ``mean + scale * eps``); otherwise gradients through the ELBO
             are biased.
@@ -54,23 +56,24 @@ class VAE(AbstractStochastic):
 
     Note:
         Unconditional distributions such as ``flowjax.distributions.Normal``
-        do **not** satisfy the :class:`ConditionalDistribution` protocol
+        do **not** satisfy the `ConditionalDistribution` protocol
         (they have no ``condition=`` kwarg). A small wrapper that amortises
         the parameters on the conditioning variable is required — see the
         ``DiagGaussianConditional`` helper used in
         ``tests/test_transforms_stochastic.py`` for a minimal reference.
 
-    Example:
-        Compose with a standard Normal prior to form a one-level VAE flow::
+    Examples:
+        Compose with a standard Normal prior to form a one-level VAE flow:
+        ```python
+        import jax.numpy as jnp
+        from flowjax.distributions import Normal
+        from gauss_flows import SurVAEFlow, VAE
 
-            import jax.numpy as jnp
-            from flowjax.distributions import Normal
-            from gauss_flows import SurVAEFlow, VAE
-
-            encoder = MyConditionalGaussian(...)   # q(z|x), reparameterized
-            decoder = MyConditionalGaussian(...)   # p(x|z)
-            vae = VAE(encoder, decoder)
-            flow = SurVAEFlow(Normal(jnp.zeros(latent_dim)), [vae])
+        encoder = MyConditionalGaussian(...)   # q(z|x), reparameterized
+        decoder = MyConditionalGaussian(...)   # p(x|z)
+        vae = VAE(encoder, decoder)
+        flow = SurVAEFlow(Normal(jnp.zeros(latent_dim)), [vae])
+        ```
 
     References:
         Nielsen, Jaini, Hoogeboom, Winther, Welling.

--- a/src/gauss_flows/_src/transforms/surjections/__init__.py
+++ b/src/gauss_flows/_src/transforms/surjections/__init__.py
@@ -5,14 +5,14 @@ many-to-one map: deterministic in one direction, stochastic in the other.
 This subpackage ships two families:
 
 **Simple surjections** — pure shape math, no learned encoder/decoder beyond
-an optional fixed conditional distribution: :class:`SimpleAbsSurjection`,
-:class:`SimpleSortSurjection`, :class:`SimpleMaxPoolSurjection2d`. All
+an optional fixed conditional distribution: `SimpleAbsSurjection`,
+`SimpleSortSurjection`, `SimpleMaxPoolSurjection2d`. All
 three are *inference* surjections (deterministic forward, stochastic
 inverse).
 
 **Encoder/decoder surjections** — change event dimensionality, take a
-conditional distribution as a constructor argument: :class:`Slice` (drops
-dims under a decoder), :class:`Augment` (adds dims under an encoder).
+conditional distribution as a constructor argument: `Slice` (drops
+dims under a decoder), `Augment` (adds dims under an encoder).
 
 References:
     Nielsen et al. (2020), *SurVAE Flows*, NeurIPS.

--- a/src/gauss_flows/_src/transforms/surjections/abs.py
+++ b/src/gauss_flows/_src/transforms/surjections/abs.py
@@ -39,7 +39,7 @@ class SimpleAbsSurjection(AbstractSurjection):
         - Output ``z``:  ``shape``    (non-negative)
         - ``log_det``:   scalar (shape ``()``)
 
-    Example:
+    Examples:
         Single-event call:
 
         >>> import jax.numpy as jnp

--- a/src/gauss_flows/_src/transforms/surjections/dimension/augment.py
+++ b/src/gauss_flows/_src/transforms/surjections/dimension/augment.py
@@ -30,7 +30,7 @@ class Augment(AbstractSurjection):
     structure that would not fit in the data dim alone.
 
     Args:
-        encoder: Object satisfying :class:`ConditionalDistribution` —
+        encoder: Object satisfying `ConditionalDistribution` —
             ``sample(key, *, condition=x)`` must produce arrays of shape
             ``(augment_size,)`` and ``log_prob(value, *, condition=x)`` must
             return a scalar.
@@ -47,7 +47,7 @@ class Augment(AbstractSurjection):
         - Output ``z``:  ``(x_size + augment_size,)``
         - ``log_det``:   scalar (shape ``()``)
 
-    Example:
+    Examples:
         Augment a 2-D data event with a 2-D learned latent:
 
         >>> import jax.numpy as jnp

--- a/src/gauss_flows/_src/transforms/surjections/dimension/slice.py
+++ b/src/gauss_flows/_src/transforms/surjections/dimension/slice.py
@@ -30,7 +30,7 @@ class Slice(AbstractSurjection):
 
     Args:
         keep_dims: Number of leading entries to keep. Must be positive.
-        decoder: Object satisfying :class:`ConditionalDistribution` —
+        decoder: Object satisfying `ConditionalDistribution` —
             ``sample(key, *, condition=z)`` must produce arrays of shape
             ``(D − keep_dims,)`` for the dropped tail and
             ``log_prob(value, *, condition=z)`` must return a scalar.
@@ -45,9 +45,9 @@ class Slice(AbstractSurjection):
         attribute. Its forward-input dim ``D`` is determined by whatever the
         upstream transform produces — it is a chain-context property, not a
         constructor parameter, so there is no fixed ``shape`` to declare. The
-        full data shape lives on :class:`SurVAEFlow.data_shape` instead.
+        full data shape lives on `SurVAEFlow.data_shape` instead.
 
-    Example:
+    Examples:
         Score the dropped tail under a unit Gaussian decoder:
 
         >>> import jax.numpy as jnp
@@ -109,7 +109,7 @@ class Slice(AbstractSurjection):
         """Sample the missing tail from the decoder; concat back.
 
         Returns ``log q(dropped_sampled | z)`` to mirror
-        ``forward_and_log_det`` and match :class:`SimpleMaxPoolSurjection2d`'s
+        ``forward_and_log_det`` and match `SimpleMaxPoolSurjection2d`'s
         inverse convention. ``SurVAEFlow.log_prob`` doesn't consume this value
         (it only uses ``forward_and_log_det``); the consistent return shape is
         for callers using the inverse standalone (e.g. ELBO computations).

--- a/src/gauss_flows/_src/transforms/surjections/pool.py
+++ b/src/gauss_flows/_src/transforms/surjections/pool.py
@@ -40,7 +40,7 @@ class SimpleMaxPoolSurjection2d(AbstractSurjection):
     Args:
         shape: Image event shape ``(H, W, C)``. Both spatial dims must be
             divisible by ``pool_size``.
-        decoder: Object satisfying :class:`ConditionalDistribution` —
+        decoder: Object satisfying `ConditionalDistribution` —
             ``sample(key, *, condition=z)`` must produce an array of shape
             ``(H/ps, W/ps, C, pool_area − 1)`` and ``log_prob(value, *,
             condition=z)`` must return a scalar.
@@ -51,18 +51,19 @@ class SimpleMaxPoolSurjection2d(AbstractSurjection):
         - Output ``z``:  ``(H/pool_size, W/pool_size, C)``
         - ``log_det``:   scalar (shape ``()``)
 
-    Example:
-        ``my_decoder`` must implement the :class:`ConditionalDistribution`
+    Examples:
+        ``my_decoder`` must implement the `ConditionalDistribution`
         protocol (see ``_src/_protocols.py``); it maps a pooled image
-        ``z`` of shape ``(4, 4, 3)`` to residuals of shape ``(4, 4, 3, 3)``::
+        ``z`` of shape ``(4, 4, 3)`` to residuals of shape ``(4, 4, 3, 3)``:
+        ```python
+        import jax.numpy as jnp
+        import jax.random as jr
+        from gauss_flows import SimpleMaxPoolSurjection2d
 
-            import jax.numpy as jnp
-            import jax.random as jr
-            from gauss_flows import SimpleMaxPoolSurjection2d
-
-            surj = SimpleMaxPoolSurjection2d((8, 8, 3), my_decoder, pool_size=2)
-            z, log_det = surj.forward_and_log_det(jnp.zeros((8, 8, 3)), jr.key(0))
-            # z.shape == (4, 4, 3); residuals.shape == (4, 4, 3, 3) (pool_area-1).
+        surj = SimpleMaxPoolSurjection2d((8, 8, 3), my_decoder, pool_size=2)
+        z, log_det = surj.forward_and_log_det(jnp.zeros((8, 8, 3)), jr.key(0))
+        # z.shape == (4, 4, 3); residuals.shape == (4, 4, 3, 3) (pool_area-1).
+        ```
     """
 
     stochastic_forward: ClassVar[bool] = False

--- a/src/gauss_flows/_src/transforms/surjections/sort.py
+++ b/src/gauss_flows/_src/transforms/surjections/sort.py
@@ -42,7 +42,7 @@ class SimpleSortSurjection(AbstractSurjection):
         - Output ``z``:  ``shape``    (sorted along ``axis``)
         - ``log_det``:   scalar (shape ``()``)
 
-    Example:
+    Examples:
         1D event:
 
         >>> import jax.numpy as jnp

--- a/tests/test_docstrings_render.py
+++ b/tests/test_docstrings_render.py
@@ -1,0 +1,118 @@
+"""Guard against docstring markup that mkdocstrings cannot render.
+
+mkdocstrings renders Google-style docstrings as Markdown. Two classes of markup
+silently break in the rendered API docs (no build warning is emitted):
+
+1. **reStructuredText markup** — Sphinx directives (``.. math::``, ``.. warning::``,
+   ``.. code-block::``), cross-reference roles (``:class:`X```, ``:func:`X```), and
+   ``::`` literal-block markers all render *literally* instead of as math / admonitions
+   / code, because the Markdown renderer does not understand RST.
+2. **Run-on examples** — griffe only recognises the **plural** ``Examples:`` section
+   (not singular ``Example:``), and inside it only ``>>>`` doctest lines or fenced
+   ```` ``` ```` blocks render as code. A singular ``Example:`` becomes a generic
+   admonition, and a plain (un-fenced, non-doctest) body collapses into one run-on
+   paragraph.
+
+This test scans every source file so a regression is caught at test time rather than
+discovered by eye on the published site. See PR discussion in the docs overhaul.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "gauss_flows"
+PY_FILES = sorted(SRC.rglob("*.py"))
+
+# RST artefacts that render literally under mkdocstrings/Markdown.
+RST_DIRECTIVE = re.compile(r"\.\. [A-Za-z-]+::")
+RST_ROLE = re.compile(r":(?:class|func|meth|mod|obj|ref|attr|data|exc|term):`")
+RST_LITERAL = re.compile(r"::\s*$")
+SINGULAR_EXAMPLE = re.compile(r"^\s*Example:\s*$")
+EXAMPLES_HEADER = re.compile(r"^(\s*)Examples:\s*$")
+FENCE = re.compile(r"^\s*```")
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(SRC.parent.parent))
+
+
+def _code_region_mask(lines: list[str]) -> list[bool]:
+    """Mark lines that live inside a fenced block or a ``>>>`` doctest block.
+
+    RST-artefact checks must skip these — a code example may legitimately contain
+    ``::`` (e.g. ``std::``) or directive-like text without it being broken markup.
+    """
+    mask = [False] * len(lines)
+    in_fence = False
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if FENCE.match(line):
+            in_fence = not in_fence
+            mask[i] = True
+            continue
+        if in_fence or stripped.startswith(">>>") or stripped.startswith("..."):
+            mask[i] = True
+    return mask
+
+
+@pytest.mark.parametrize("path", PY_FILES, ids=_rel)
+def test_no_rst_markup(path: Path) -> None:
+    """Docstrings must use Markdown + ``$...$`` math, not reStructuredText."""
+    lines = path.read_text().split("\n")
+    in_code = _code_region_mask(lines)
+    bad: list[str] = []
+    for i, line in enumerate(lines, start=1):
+        if in_code[i - 1] or "http" in line:
+            continue
+        if RST_DIRECTIVE.search(line):
+            bad.append(f"  {_rel(path)}:{i}: RST directive → {line.strip()[:60]}")
+        if RST_ROLE.search(line):
+            bad.append(f"  {_rel(path)}:{i}: RST role → {line.strip()[:60]}")
+        if RST_LITERAL.search(line):
+            bad.append(
+                f"  {_rel(path)}:{i}: RST '::' literal block → {line.strip()[:60]}"
+            )
+    assert not bad, (
+        "reStructuredText markup does not render in mkdocstrings:\n" + "\n".join(bad)
+    )
+
+
+@pytest.mark.parametrize("path", PY_FILES, ids=_rel)
+def test_examples_section_renders(path: Path) -> None:
+    """Example sections must be plural ``Examples:`` with a code body.
+
+    griffe only recognises ``Examples:`` (plural), and only renders ``>>>`` doctest
+    lines or fenced code as code; anything else collapses into a run-on paragraph.
+    """
+    lines = path.read_text().split("\n")
+    bad: list[str] = []
+    for i, line in enumerate(lines):
+        if SINGULAR_EXAMPLE.match(line):
+            bad.append(
+                f"  {_rel(path)}:{i + 1}: singular 'Example:' is not recognised — "
+                "use plural 'Examples:'"
+            )
+        m = EXAMPLES_HEADER.match(line)
+        if not m:
+            continue
+        indent = len(m.group(1))
+        body: list[str] = []
+        for nxt in lines[i + 1 :]:
+            if not nxt.strip():
+                body.append(nxt)
+                continue
+            if len(nxt) - len(nxt.lstrip()) <= indent:
+                break
+            body.append(nxt)
+        body_text = "\n".join(body)
+        if ">>>" not in body_text and "```" not in body_text:
+            bad.append(
+                f"  {_rel(path)}:{i + 1}: 'Examples:' body has no '>>>' or fenced "
+                "block — it will render as a run-on paragraph"
+            )
+    assert not bad, "Example sections will not render as code:\n" + "\n".join(bad)


### PR DESCRIPTION
## Why

Two classes of docstring markup were rendering incorrectly on the docs site, and mkdocstrings emits **no build warning** for either:

1. **Examples rendered as a run-on paragraph.** griffe's Google parser only recognizes the **plural `Examples:`** section; the codebase used singular **`Example:` (76 times)**, which falls through to a generic admonition that collapses the code into one paragraph. Even inside a real `Examples:` section, only `>>>` doctest lines or fenced ```` ``` ```` blocks render as code.
2. **Equations rendered literally.** Several docstrings used reStructuredText (`.. math::`, `:math:`, `:class:`/`:func:`/`:meth:`/`:mod:`, `.. warning::`, `::` literal blocks, RST section underlines). mkdocstrings renders Markdown, so RST shows up verbatim (`conv_exp.py` was almost entirely RST).

## What changed

- `Example:` → `Examples:` everywhere; fenced the non-doctest (slow training/MC/ODE) example bodies so they render as code rather than run-on.
- Converted RST → Markdown/MathJax: `.. math::`→`$$`, `:math:`→`$…$`, cross-ref roles→inline code, `.. warning::`→`!!! warning`, `.. code-block::`/`::` literals→fenced code, RST underlines→bold.
- **`tests/test_docstrings_render.py`** — scans every source file and fails on (a) RST markup, (b) singular `Example:`, or (c) an `Examples:` body with no `>>>`/fence (would render run-on). Runs in the normal fast suite.

## Verification

- Rebuilt the site and inspected the generated HTML: previously-broken symbols (`CircularRQSplineCoupling`, `OrthogonalConvExponential`) now render as **highlighted code blocks** with MathJax math; literal `.. math::` count = **0**.
- `mkdocs build` — **0 warnings**.
- New render-guard test passes (and was confirmed to fail on the old markup).
- `ruff check`/`format`, `ty check` — clean.
- Full fast suite — **571 passed, 90.21% coverage**.

https://claude.ai/code/session_01KSt4pcUNbRFb2ZRgrW7oFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSt4pcUNbRFb2ZRgrW7oFX)_